### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ Get a .deb file from the [release page](https://github.com/sezanzeb/key-mapper/r
 or install the latest changes via:
 
 ```bash
-sudo apt install git python3-setuptools
+sudo apt install git python3-setuptools gettext
 git clone https://github.com/sezanzeb/key-mapper.git
-cd key-mapper; ./scripts/build.sh
+cd key-mapper && ./scripts/build.sh
 sudo apt install ./dist/key-mapper-1.0.0.deb
 ```
 


### PR DESCRIPTION
- Added gettext to the apt install parameters, a dependecy of msgfmt used in the setup.py routine, missing in a clean Debian 11 Bulleye.
- Replaced ; with && in 'cd key-mapper; ./scripts/build.sh'