### PR TITLE
allow autoload command to execute if `config_dir` is provided

### DIFF
--- a/bin/key-mapper-control
+++ b/bin/key-mapper-control
@@ -205,7 +205,7 @@ def main(options):
 
     logger.debug('Call for "%s"', sys.argv)
 
-    if options.command == AUTOLOAD and num_logged_in_users() == 0:
+    if options.command == AUTOLOAD and num_logged_in_users() == 0 and options.config_dir is None:
         # No user logged in, this is probably happening during boot time and got
         # triggered by udev. There is no need to try to inject anything if the
         # service doesn't know where to look for a config file. This avoids a lot

--- a/data/key-mapper-autoload.desktop
+++ b/data/key-mapper-autoload.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-Exec=bash -c "key-mapper-control --command stop-all && key-mapper-control --command autoload"
+Exec=bash -c "key-mapper-control --command stop-all; key-mapper-control --command autoload --config-dir /home/USER/.config/key-mapper"
 Name=key-mapper-autoload
 Icon=/usr/share/key-mapper/key-mapper.svg
 Comment=Starts injecting all presets that are set to automatically load for the user


### PR DESCRIPTION
I have a Linux machine that does not show any `logged in users` with the `who` command even when I am using the machine.
It is perhaps a specialized use-case but I don't see why you need a logged in user in order to activate the mapping IF a config directory has been provided which contains the relevant configuration for key-mapper.

The machine in question is a JingPad A1.  

```
tmclane@JingOS:/media/tmclane/data/key-mapper$ who
tmclane@JingOS:/media/tmclane/data/key-mapper$ whoami
tmclane
```