### PR TITLE
the ui no longer records keycodes if the preset is active

### DIFF
--- a/inputremapper/gui/user_interface.py
+++ b/inputremapper/gui/user_interface.py
@@ -390,7 +390,7 @@ class UserInterface:
         preset_selection.set_active(0)
 
     def can_modify_mapping(self, *_) -> bool:
-        """Show a message if changing the mapping is not possible."""
+        """if changing the mapping is possible."""
         return self.dbus.get_state(self.group.key) != RUNNING
 
     def consume_newest_keycode(self):

--- a/inputremapper/gui/user_interface.py
+++ b/inputremapper/gui/user_interface.py
@@ -389,15 +389,9 @@ class UserInterface:
         # and select the newest one (on the top). triggers on_select_preset
         preset_selection.set_active(0)
 
-    def can_modify_mapping(self, *_):
+    def can_modify_mapping(self, *_) -> bool:
         """Show a message if changing the mapping is not possible."""
-        if self.dbus.get_state(self.group.key) != RUNNING:
-            return
-
-        # because the device is in grab mode by the daemon and
-        # therefore the original keycode inaccessible
-        logger.info("Cannot change keycodes while injecting")
-        self.show_status(CTX_ERROR, 'Use "Stop Injection" to stop before editing')
+        return self.dbus.get_state(self.group.key) != RUNNING
 
     def consume_newest_keycode(self):
         """To capture events from keyboards, mice and gamepads."""

--- a/tests/testcases/test_gui.py
+++ b/tests/testcases/test_gui.py
@@ -83,7 +83,7 @@ Gtk.main = gtk_iteration
 Gtk.main_quit = lambda: None
 
 
-def launch(argv=None):
+def launch(argv=None) -> UserInterface:
     """Start input-remapper-gtk with the command line argument array argv."""
     bin_path = os.path.join(os.getcwd(), "bin", "input-remapper-gtk")
 
@@ -1558,14 +1558,24 @@ class TestGui(GuiTestBase, unittest.TestCase):
             time.sleep(0.1)
             gtk_iteration()
             if "Starting" not in self.get_status_text():
-                return
+                break
 
         self.assertEqual(
             self.user_interface.dbus.get_state(self.user_interface.group.key), RUNNING
         )
 
         # the mapping cannot be changed anymore
-        self.user_interface.can_modify_mapping()
+        self.assertFalse(self.user_interface.can_modify_mapping())
+
+        # the toggle button should reset itself shortly
+        self.user_interface.editor.get_recording_toggle().set_active(True)
+        for _ in range(10):
+            time.sleep(0.1)
+            gtk_iteration()
+            if not self.user_interface.editor.get_recording_toggle().get_active():
+                break
+
+        self.assertFalse(self.user_interface.editor.get_recording_toggle().get_active())
         text = self.get_status_text()
         self.assertIn("Stop Injection", text)
 


### PR DESCRIPTION
since there can be multiple evdev devices in the same group it was possible to record keycodes even if the injection was active. This was confusing behaviour.