### PR TITLE
Use tempfiles instead of hardcoded /tmp

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -120,10 +120,6 @@ uinput_write_history_pipe = multiprocessing.Pipe()
 pending_events = {}
 
 
-if os.path.exists(tmp):
-    shutil.rmtree(tmp)
-
-
 def read_write_history_pipe():
     """convert the write history from the pipe to some easier to manage list"""
     history = []

--- a/tests/test.py
+++ b/tests/test.py
@@ -111,7 +111,7 @@ MIN_ABS = -(2 ** 15)
 MAX_ABS = 2 ** 15
 
 tmp_TemporaryDirectory = tempfile.TemporaryDirectory(prefix="input-remapper-test")
-tmp = str(tmp_TemporaryDirectory)
+tmp = tmp_TemporaryDirectory.name
 uinput_write_history = []
 # for tests that makes the injector create its processes
 uinput_write_history_pipe = multiprocessing.Pipe()

--- a/tests/test.py
+++ b/tests/test.py
@@ -110,8 +110,10 @@ START_READING_DELAY = 0.05
 MIN_ABS = -(2 ** 15)
 MAX_ABS = 2 ** 15
 
-tmp_TemporaryDirectory = tempfile.TemporaryDirectory(prefix="input-remapper-test")
-tmp = tmp_TemporaryDirectory.name
+# When it gets garbage collected it cleans up the temporary directory so it needs to
+# stay reachable while the tests are ran.
+temporary_directory = tempfile.TemporaryDirectory(prefix="input-remapper-test")
+tmp = temporary_directory.name
 uinput_write_history = []
 # for tests that makes the injector create its processes
 uinput_write_history_pipe = multiprocessing.Pipe()

--- a/tests/test.py
+++ b/tests/test.py
@@ -114,6 +114,7 @@ MAX_ABS = 2 ** 15
 # stay reachable while the tests are ran.
 temporary_directory = tempfile.TemporaryDirectory(prefix="input-remapper-test")
 tmp = temporary_directory.name
+
 uinput_write_history = []
 # for tests that makes the injector create its processes
 uinput_write_history_pipe = multiprocessing.Pipe()

--- a/tests/test.py
+++ b/tests/test.py
@@ -22,6 +22,7 @@
 """Sets up inputremapper for the tests and runs them."""
 import os
 import sys
+import tempfile
 
 # the working directory should be the project root
 assert not os.getcwd().endswith("tests")
@@ -109,8 +110,8 @@ START_READING_DELAY = 0.05
 MIN_ABS = -(2 ** 15)
 MAX_ABS = 2 ** 15
 
-
-tmp = "/tmp/input-remapper-test"
+tmp_TemporaryDirectory = tempfile.TemporaryDirectory(prefix="input-remapper-test")
+tmp = str(tmp_TemporaryDirectory)
 uinput_write_history = []
 # for tests that makes the injector create its processes
 uinput_write_history_pipe = multiprocessing.Pipe()
@@ -292,7 +293,7 @@ def new_event(type, code, value, timestamp=None, offset=0):
 def patch_paths():
     from inputremapper import paths
 
-    paths.CONFIG_PATH = "/tmp/input-remapper-test"
+    paths.CONFIG_PATH = tmp
 
 
 class InputDevice:

--- a/tests/testcases/test_ipc.py
+++ b/tests/testcases/test_ipc.py
@@ -22,6 +22,7 @@
 import unittest
 import select
 import time
+import os
 
 from inputremapper.ipc.pipe import Pipe
 from inputremapper.ipc.shared_dict import SharedDict
@@ -70,21 +71,21 @@ class TestSocket(unittest.TestCase):
             self.assertFalse(s2.poll())
             self.assertEqual(s2.recv(), None)
 
-        server = Server(tmp + "/socket1")
-        client = Client(tmp + "/socket1")
+        server = Server(os.path.join(tmp, "socket1"))
+        client = Client(os.path.join(tmp, "socket1"))
         test(server, client)
 
-        client = Client(tmp + "/socket2")
-        server = Server(tmp + "/socket2")
+        client = Client(os.path.join(tmp, "socket2"))
+        server = Server(os.path.join(tmp, "socket2"))
         test(client, server)
 
     def test_not_connected_1(self):
         # client discards old message, because it might have had a purpose
         # for a different client and not for the current one
-        server = Server(tmp + "/socket3")
+        server = Server(os.path.join(tmp, "socket3"))
         server.send(1)
 
-        client = Client(tmp + "/socket3")
+        client = Client(os.path.join(tmp, "socket3"))
         server.send(2)
 
         self.assertTrue(client.poll())
@@ -93,10 +94,10 @@ class TestSocket(unittest.TestCase):
         self.assertEqual(client.recv(), None)
 
     def test_not_connected_2(self):
-        client = Client(tmp + "/socket4")
+        client = Client(os.path.join(tmp, "socket4"))
         client.send(1)
 
-        server = Server(tmp + "/socket4")
+        server = Server(os.path.join(tmp, "socket4"))
         client.send(2)
 
         self.assertTrue(server.poll())
@@ -106,8 +107,8 @@ class TestSocket(unittest.TestCase):
 
     def test_select(self):
         """is compatible to select.select"""
-        server = Server(tmp + "/socket6")
-        client = Client(tmp + "/socket6")
+        server = Server(os.path.join(tmp, "socket6"))
+        client = Client(os.path.join(tmp, "socket6"))
 
         server.send(1)
         ready = select.select([client], [], [], 0)[0][0]
@@ -126,7 +127,7 @@ class TestSocket(unittest.TestCase):
 
 class TestPipe(unittest.TestCase):
     def test_pipe_single(self):
-        p1 = Pipe(tmp + "/pipe")
+        p1 = Pipe(os.path.join(tmp, "pipe"))
         self.assertEqual(p1.recv(), None)
 
         p1.send(1)
@@ -146,8 +147,8 @@ class TestPipe(unittest.TestCase):
         self.assertEqual(p1.recv(), None)
 
     def test_pipe_duo(self):
-        p1 = Pipe(tmp + "/pipe")
-        p2 = Pipe(tmp + "/pipe")
+        p1 = Pipe(os.path.join(tmp, "pipe"))
+        p2 = Pipe(os.path.join(tmp, "pipe"))
         self.assertEqual(p2.recv(), None)
 
         p1.send(1)

--- a/tests/testcases/test_ipc.py
+++ b/tests/testcases/test_ipc.py
@@ -27,7 +27,7 @@ from inputremapper.ipc.pipe import Pipe
 from inputremapper.ipc.shared_dict import SharedDict
 from inputremapper.ipc.socket import Server, Client, Base
 
-from tests.test import quick_cleanup
+from tests.test import quick_cleanup, tmp
 
 
 class TestSharedDict(unittest.TestCase):
@@ -70,21 +70,21 @@ class TestSocket(unittest.TestCase):
             self.assertFalse(s2.poll())
             self.assertEqual(s2.recv(), None)
 
-        server = Server("/tmp/input-remapper-test/socket1")
-        client = Client("/tmp/input-remapper-test/socket1")
+        server = Server(tmp + "/socket1")
+        client = Client(tmp + "/socket1")
         test(server, client)
 
-        client = Client("/tmp/input-remapper-test/socket2")
-        server = Server("/tmp/input-remapper-test/socket2")
+        client = Client(tmp + "/socket2")
+        server = Server(tmp + "/socket2")
         test(client, server)
 
     def test_not_connected_1(self):
         # client discards old message, because it might have had a purpose
         # for a different client and not for the current one
-        server = Server("/tmp/input-remapper-test/socket3")
+        server = Server(tmp + "/socket3")
         server.send(1)
 
-        client = Client("/tmp/input-remapper-test/socket3")
+        client = Client(tmp + "/socket3")
         server.send(2)
 
         self.assertTrue(client.poll())
@@ -93,10 +93,10 @@ class TestSocket(unittest.TestCase):
         self.assertEqual(client.recv(), None)
 
     def test_not_connected_2(self):
-        client = Client("/tmp/input-remapper-test/socket4")
+        client = Client(tmp + "/socket4")
         client.send(1)
 
-        server = Server("/tmp/input-remapper-test/socket4")
+        server = Server(tmp + "/socket4")
         client.send(2)
 
         self.assertTrue(server.poll())
@@ -106,8 +106,8 @@ class TestSocket(unittest.TestCase):
 
     def test_select(self):
         """is compatible to select.select"""
-        server = Server("/tmp/input-remapper-test/socket6")
-        client = Client("/tmp/input-remapper-test/socket6")
+        server = Server(tmp + "/socket6")
+        client = Client(tmp + "/socket6")
 
         server.send(1)
         ready = select.select([client], [], [], 0)[0][0]
@@ -126,7 +126,7 @@ class TestSocket(unittest.TestCase):
 
 class TestPipe(unittest.TestCase):
     def test_pipe_single(self):
-        p1 = Pipe(f"/tmp/input-remapper-test/pipe")
+        p1 = Pipe(tmp + "/pipe")
         self.assertEqual(p1.recv(), None)
 
         p1.send(1)
@@ -146,8 +146,8 @@ class TestPipe(unittest.TestCase):
         self.assertEqual(p1.recv(), None)
 
     def test_pipe_duo(self):
-        p1 = Pipe(f"/tmp/input-remapper-test/pipe")
-        p2 = Pipe(f"/tmp/input-remapper-test/pipe")
+        p1 = Pipe(tmp + "/pipe")
+        p2 = Pipe(tmp + "/pipe")
         self.assertEqual(p2.recv(), None)
 
         p1.send(1)

--- a/tests/testcases/test_migrations.py
+++ b/tests/testcases/test_migrations.py
@@ -59,7 +59,7 @@ class TestMigrations(unittest.TestCase):
         new = CONFIG_PATH
 
         # we are not destroying our actual config files with this test
-        self.assertTrue(new.startswith("/tmp"))
+        self.assertTrue(new.startswith(tmp))
 
         try:
             shutil.rmtree(new)

--- a/tests/testcases/test_paths.py
+++ b/tests/testcases/test_paths.py
@@ -26,7 +26,6 @@ from inputremapper.paths import touch, mkdir, get_preset_path, get_config_path
 
 from tests.test import quick_cleanup, tmp
 
-
 def _raise(error):
     raise error
 
@@ -36,15 +35,15 @@ class TestPaths(unittest.TestCase):
         quick_cleanup()
 
     def test_touch(self):
-        touch("/tmp/a/b/c/d/e")
-        self.assertTrue(os.path.exists("/tmp/a/b/c/d/e"))
-        self.assertTrue(os.path.isfile("/tmp/a/b/c/d/e"))
-        self.assertRaises(ValueError, lambda: touch("/tmp/a/b/c/d/f/"))
+        touch(tmp + "/a/b/c/d/e")
+        self.assertTrue(os.path.exists(tmp + "/a/b/c/d/e"))
+        self.assertTrue(os.path.isfile(tmp + "/a/b/c/d/e"))
+        self.assertRaises(ValueError, lambda: touch(tmp + "/a/b/c/d/f/"))
 
     def test_mkdir(self):
-        mkdir("/tmp/b/c/d/e")
-        self.assertTrue(os.path.exists("/tmp/b/c/d/e"))
-        self.assertTrue(os.path.isdir("/tmp/b/c/d/e"))
+        mkdir(tmp + "/b/c/d/e")
+        self.assertTrue(os.path.exists(tmp + "/b/c/d/e"))
+        self.assertTrue(os.path.isdir(tmp + "/b/c/d/e"))
 
     def test_get_preset_path(self):
         self.assertEqual(get_preset_path(), os.path.join(tmp, "presets"))

--- a/tests/testcases/test_paths.py
+++ b/tests/testcases/test_paths.py
@@ -21,6 +21,7 @@
 
 import os
 import unittest
+import tempfile
 
 from inputremapper.paths import touch, mkdir, get_preset_path, get_config_path
 
@@ -35,15 +36,19 @@ class TestPaths(unittest.TestCase):
         quick_cleanup()
 
     def test_touch(self):
-        touch(tmp + "/a/b/c/d/e")
-        self.assertTrue(os.path.exists(tmp + "/a/b/c/d/e"))
-        self.assertTrue(os.path.isfile(tmp + "/a/b/c/d/e"))
-        self.assertRaises(ValueError, lambda: touch(tmp + "/a/b/c/d/f/"))
+        with tempfile.TemporaryDirectory() as local_tmp:
+            path_abcde = os.path.join(local_tmp, "a/b/c/d/e")
+            touch(path_abcde)
+            self.assertTrue(os.path.exists(path_abcde))
+            self.assertTrue(os.path.isfile(path_abcde))
+            self.assertRaises(ValueError, lambda: touch(os.path.join(local_tmp, "a/b/c/d/f/")))
 
     def test_mkdir(self):
-        mkdir(tmp + "/b/c/d/e")
-        self.assertTrue(os.path.exists(tmp + "/b/c/d/e"))
-        self.assertTrue(os.path.isdir(tmp + "/b/c/d/e"))
+        with tempfile.TemporaryDirectory() as local_tmp:
+            path_bcde = os.path.join(local_tmp, "b/c/d/e")
+            mkdir(path_bcde)
+            self.assertTrue(os.path.exists(path_bcde))
+            self.assertTrue(os.path.isdir(path_bcde))
 
     def test_get_preset_path(self):
         self.assertEqual(get_preset_path(), os.path.join(tmp, "presets"))

--- a/tests/testcases/test_presets.py
+++ b/tests/testcases/test_presets.py
@@ -172,7 +172,7 @@ class TestFindPresets(unittest.TestCase):
         path = os.path.join(PRESETS, "Bar Device", "picture.png")
         os.mknod(path)
 
-        os.system("find /tmp/input-remapper-test/")
+        os.system("find " + tmp + "/")
         self.assertEqual(find_newest_preset(), ("Bar Device", "preset 2"))
 
     def test_find_newest_preset_2(self):

--- a/tests/testcases/test_presets.py
+++ b/tests/testcases/test_presets.py
@@ -172,7 +172,7 @@ class TestFindPresets(unittest.TestCase):
         path = os.path.join(PRESETS, "Bar Device", "picture.png")
         os.mknod(path)
 
-        os.system("find " + tmp + "/")
+        os.system(f"find {tmp}/")
         self.assertEqual(find_newest_preset(), ("Bar Device", "preset 2"))
 
     def test_find_newest_preset_2(self):

--- a/tests/testcases/test_presets.py
+++ b/tests/testcases/test_presets.py
@@ -172,7 +172,6 @@ class TestFindPresets(unittest.TestCase):
         path = os.path.join(PRESETS, "Bar Device", "picture.png")
         os.mknod(path)
 
-        os.system(f"find {tmp}/")
         self.assertEqual(find_newest_preset(), ("Bar Device", "preset 2"))
 
     def test_find_newest_preset_2(self):


### PR DESCRIPTION
/tmp isn't guaranteed to be the correct place for temporary files in all environments, use tempfiles instead which checks appropriate environment variables.

Expected behavior with this change:

* Temp files end up in `$TMP/input-remapper-test<randomstring>`.
* * If $TMP isn't set, it falls back to the system default /tmp.
* Temp files are cleaned up after tests run if anything is left over
* Temp files won't end up in the current working directory