### PR TITLE
Use non-zero exit code if tests fail

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -35,7 +35,6 @@ if __name__ == "__main__":
     import tests.test
 
     tests.test.main()
-    sys.exit(0)
 
 import shutil
 import time
@@ -689,4 +688,5 @@ def main():
         print()
 
     unittest.TextTestResult.startTest = start_test
-    unittest.TextTestRunner(verbosity=2).run(testsuite)
+    result = unittest.TextTestRunner(verbosity=2).run(testsuite)
+    sys.exit(not result.wasSuccessful())


### PR DESCRIPTION
Lets tools running the tests know if any failed without having to parse the output.