### PR TITLE
Mapping to " " caused problems, general test improvements

### DIFF
--- a/inputremapper/gui/editor/editor.py
+++ b/inputremapper/gui/editor/editor.py
@@ -464,7 +464,7 @@ class Editor:
             # not configured yet
             return ""
 
-        return symbol
+        return symbol.strip()
 
     def set_target_selection(self, target):
         selector = self.get_target_selector()
@@ -552,7 +552,7 @@ class Editor:
 
         # make sure the active_preset is up to date
         key = self.get_combination()
-        if correct_case is not None and key is not None and target is not None:
+        if correct_case and key and target:
             active_preset.change(key, target, correct_case)
 
         # save to disk if required

--- a/inputremapper/gui/editor/editor.py
+++ b/inputremapper/gui/editor/editor.py
@@ -378,6 +378,7 @@ class Editor:
             if active_preset.get_mapping(combination):
                 self.set_symbol_input_text(active_preset.get_mapping(combination)[0])
                 self.set_target_selection(active_preset.get_mapping(combination)[1])
+
             self.enable_symbol_input()
             self.enable_target_selector()
 

--- a/tests/integration/test_gui.py
+++ b/tests/integration/test_gui.py
@@ -1982,14 +1982,17 @@ class TestGui(GuiTestBase):
         self.editor.enable_symbol_input()
         self.assertEqual(self.get_unfiltered_symbol_input_text(), "foo")
 
-    def test_empty_symbol(self):
-        # test how the editor behaves when the text of a mapping is removed
+    def test_whitespace_symbol(self):
+        # test how the editor behaves when the text of a mapping is a whitespace.
+        # Caused an "Expected `symbol` not to be empty" error in the past, because
+        # the symbol was not stripped of whitespaces and logic was performed that
+        # resulted in a call to actually changing the mapping.
         self.add_mapping_via_ui(EventCombination([1, 201, 1]), "a")
         self.add_mapping_via_ui(EventCombination([1, 202, 1]), "b")
 
         self.select_mapping(1)
         self.assertEqual(self.editor.get_symbol_input_text(), "b")
-        self.editor.set_symbol_input_text("")
+        self.editor.set_symbol_input_text(" ")
 
         self.select_mapping(0)
         self.assertEqual(self.editor.get_symbol_input_text(), "a")

--- a/tests/integration/test_gui.py
+++ b/tests/integration/test_gui.py
@@ -19,6 +19,22 @@
 # along with input-remapper.  If not, see <https://www.gnu.org/licenses/>.
 
 
+# the tests file needs to be imported first to make sure patches are loaded
+from tests.test import (
+    get_project_root,
+    logger,
+    tmp,
+    push_events,
+    new_event,
+    spy,
+    cleanup,
+    uinput_write_history_pipe,
+    MAX_ABS,
+    EVENT_READ_TIMEOUT,
+    send_event_to_reader,
+    MIN_ABS,
+)
+
 import sys
 import time
 import atexit
@@ -61,20 +77,6 @@ from inputremapper.event_combination import EventCombination
 from inputremapper.daemon import Daemon
 from inputremapper.groups import groups
 
-from tests.test import (
-    logger,
-    tmp,
-    push_events,
-    new_event,
-    spy,
-    cleanup,
-    uinput_write_history_pipe,
-    MAX_ABS,
-    EVENT_READ_TIMEOUT,
-    send_event_to_reader,
-    MIN_ABS,
-)
-
 
 # iterate a few times when Gtk.main() is called, but don't block
 # there and just continue to the tests while the UI becomes
@@ -87,7 +89,7 @@ Gtk.main_quit = lambda: None
 
 def launch(argv=None) -> UserInterface:
     """Start input-remapper-gtk with the command line argument array argv."""
-    bin_path = os.path.join(os.getcwd(), "bin", "input-remapper-gtk")
+    bin_path = os.path.join(get_project_root(), "bin", "input-remapper-gtk")
 
     if not argv:
         argv = ["-d"]

--- a/tests/test.py
+++ b/tests/test.py
@@ -26,26 +26,12 @@ import sys
 import tempfile
 
 
-def chdir_to_project_root():
-    """Change the current workig directory to input-remappers root.
-
-    When using the green arrow on the left to run tests in pycharm, the working
-    directory is usually the parent directory of the test. This fixes it.
-    """
-    for _ in range(10):
-        # go up until it is found
-        if "setup.py" not in os.listdir("."):
-            os.chdir("..")
-        else:
-            break
-    else:
-        # it probably keeps looping forever because it can't find the project root.
-        # Setup your working directory to the project root (see "Edit Configurations"
-        # in pycharm).
-        raise Exception("Your working directory test setup is broken")
-
-
-chdir_to_project_root()
+if "setup.py" not in os.listdir("."):
+    # Setup your working directory to the project root
+    # (see "Edit Configurations" in pycharm).
+    # This is needed in order to make the tests module visible, so that fixtures
+    # can be imported and patches loaded.
+    raise Exception("Your working directory test setup is broken")
 
 
 # make sure the "tests" module visible
@@ -474,6 +460,7 @@ class InputEvent(evdev.InputEvent):
 
 
 def patch_evdev():
+    print("patch evdev du mongo")
     def list_devices():
         return fixtures.keys()
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -26,16 +26,22 @@ import sys
 import tempfile
 
 
-if "setup.py" not in os.listdir("."):
-    # Setup your working directory to the project root
-    # (see "Edit Configurations" in pycharm).
-    # This is needed in order to make the tests module visible, so that fixtures
-    # can be imported and patches loaded.
-    raise Exception("Your working directory test setup is broken")
+def get_project_root():
+    """Find the projects root, i.e. the uppermost directory of the repo."""
+    # when tests are started in pycharm via the green arrow, the working directory
+    # is not the project root. Go up until it is found.
+    root = os.getcwd()
+    for _ in range(10):
+        if "setup.py" in os.listdir(root):
+            return root
+
+        root = os.path.dirname(root)
+
+    raise Exception("Could not find project root")
 
 
 # make sure the "tests" module visible
-sys.path.append(os.getcwd())
+sys.path.append(get_project_root())
 if __name__ == "__main__":
     # import this file to itself to make sure is not run twice and all global
     # variables end up in sys.modules
@@ -460,7 +466,6 @@ class InputEvent(evdev.InputEvent):
 
 
 def patch_evdev():
-    print("patch evdev du mongo")
     def list_devices():
         return fixtures.keys()
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -25,15 +25,34 @@ import os
 import sys
 import tempfile
 
-# the working directory should be the project root
-assert not os.getcwd().endswith("tests")
-assert not os.getcwd().endswith("unit")
-assert not os.getcwd().endswith("integration")
+
+def chdir_to_project_root():
+    """Change the current workig directory to input-remappers root.
+
+    When using the green arrow on the left to run tests in pycharm, the working
+    directory is usually the parent directory of the test. This fixes it.
+    """
+    for _ in range(10):
+        # go up until it is found
+        if "setup.py" not in os.listdir("."):
+            os.chdir("..")
+        else:
+            break
+    else:
+        # it probably keeps looping forever because it can't find the project root.
+        # Setup your working directory to the project root (see "Edit Configurations"
+        # in pycharm).
+        raise Exception("Your working directory test setup is broken")
+
+
+chdir_to_project_root()
+
 
 # make sure the "tests" module visible
 sys.path.append(os.getcwd())
 if __name__ == "__main__":
-    # import this file to itself to make sure is not run twice and all global variables end up in sys.modules
+    # import this file to itself to make sure is not run twice and all global
+    # variables end up in sys.modules
     # https://stackoverflow.com/questions/13181559/importing-modules-main-vs-import-as-module
     import tests.test
 


### PR DESCRIPTION
- running tests in pycharm via the green arrow next to individual tests works now
- added more logs to tests to better understand what the tests are doing
- added test that maps to " " and then selects a different mapping and fixed the exception that came after it