### PR TITLE
Added hold_keys, rearranged test imports, removed deprecated macro capability tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ cd input-remapper && ./scripts/build.sh
 sudo apt install ./dist/input-remapper-1.4.1.deb
 ```
 
-input-remapper is now part of [Debian Unstable](https://packages.debian.org/sid/key-mapper)
+input-remapper is now part of [Debian Unstable](https://packages.debian.org/sid/input-remapper)
 
 ##### pip
 

--- a/inputremapper/configs/migrations.py
+++ b/inputremapper/configs/migrations.py
@@ -155,10 +155,13 @@ def _rename_config():
 def _find_target(symbol):
     """try to find a uinput with the required capabilities for the symbol."""
     capabilities = {EV_KEY: set(), EV_REL: set()}
-    if is_this_a_macro(symbol):
-        capabilities = parse(symbol).get_capabilities()
-    else:
-        capabilities[EV_KEY] = {system_mapping.get(symbol)}
+
+    if not is_this_a_macro(symbol):
+        # deprecated mechanic, cannot figure this out anymore
+        # capabilities = parse(symbol).get_capabilities()
+        return None
+
+    capabilities[EV_KEY] = {system_mapping.get(symbol)}
 
     if len(capabilities[EV_REL]) > 0:
         return "mouse"

--- a/inputremapper/configs/migrations.py
+++ b/inputremapper/configs/migrations.py
@@ -156,7 +156,7 @@ def _find_target(symbol):
     """try to find a uinput with the required capabilities for the symbol."""
     capabilities = {EV_KEY: set(), EV_REL: set()}
 
-    if not is_this_a_macro(symbol):
+    if is_this_a_macro(symbol):
         # deprecated mechanic, cannot figure this out anymore
         # capabilities = parse(symbol).get_capabilities()
         return None

--- a/inputremapper/gui/editor/editor.py
+++ b/inputremapper/gui/editor/editor.py
@@ -187,7 +187,6 @@ class Editor:
         One could debounce saving on text-change to avoid those logs, but that just
         sounds like a huge source of race conditions and is also hard to test.
         """
-        print("on_text_input_unfocus")
         pass  # the decorator will be triggered
 
     @ensure_everything_saved

--- a/inputremapper/gui/user_interface.py
+++ b/inputremapper/gui/user_interface.py
@@ -391,6 +391,7 @@ class UserInterface:
         # and select the newest one (on the top). triggers on_select_preset
         preset_selection.set_active(0)
 
+    @if_group_selected
     def can_modify_preset(self, *args) -> bool:
         """if changing the preset is possible."""
         return self.dbus.get_state(self.group.key) != RUNNING

--- a/inputremapper/gui/user_interface.py
+++ b/inputremapper/gui/user_interface.py
@@ -26,9 +26,6 @@ import math
 import os
 import re
 import sys
-import locale
-import gettext
-from inputremapper.configs.data import get_data_path
 from inputremapper.gui.gettext import _
 
 from evdev._ecodes import EV_KEY

--- a/inputremapper/injection/macros/macro.py
+++ b/inputremapper/injection/macros/macro.py
@@ -438,7 +438,7 @@ class Macro:
         ----------
         type_: str or int
             examples: 2, 'EV_KEY'
-        code : int or int
+        code : str or int
             examples: 52, 'KEY_A'
         value : int
         """

--- a/inputremapper/injection/macros/macro.py
+++ b/inputremapper/injection/macros/macro.py
@@ -340,9 +340,13 @@ class Macro:
         if not isinstance(macro, Macro):
             # if macro is a key name, hold down the key while the
             # keyboard key is physically held down
-            code = _type_check_symbol(macro)
+            symbol = macro
+            _type_check_symbol(symbol)
 
             async def task(handler):
+                resolved_symbol = _resolve(symbol, [str])
+                code = _type_check_symbol(resolved_symbol)
+
                 resolved_code = _resolve(code, [int])
                 handler(EV_KEY, resolved_code, 1)
                 await self._trigger_release_event.wait()

--- a/inputremapper/injection/macros/parse.py
+++ b/inputremapper/injection/macros/parse.py
@@ -49,6 +49,7 @@ FUNCTIONS = {
     "event": Macro.add_event,
     "wait": Macro.add_wait,
     "hold": Macro.add_hold,
+    "hold_keys": Macro.add_hold_keys,
     "mouse": Macro.add_mouse,
     "wheel": Macro.add_wheel,
     "if_eq": Macro.add_if_eq,
@@ -94,16 +95,28 @@ def get_macro_argument_names(function):
 
     Removes the trailing "_" for displaying them correctly.
     """
-    # don't include "self"
-    args = inspect.getfullargspec(function).args[1:]
-    return [name[:-1] if name.endswith("_") else name for name in args]
+    args = inspect.getfullargspec(function).args[1:]  # don't include "self"
+    arg_names = [name[:-1] if name.endswith("_") else name for name in args]
+
+    varargs = inspect.getfullargspec(function).varargs
+    if varargs:
+        arg_names.append(f"*{varargs}")
+
+    return arg_names
 
 
 def get_num_parameters(function):
     """Get the number of required parameters and the maximum number of parameters."""
     fullargspec = inspect.getfullargspec(function)
-    num_args = len(fullargspec.args) - 1  # one is `self`
-    return num_args - len(fullargspec.defaults or ()), num_args
+    num_args = len(fullargspec.args) - 1  # one of them is `self`
+    min_num_args = num_args - len(fullargspec.defaults or ())
+
+    if fullargspec.varargs is not None:
+        max_num_args = float("inf")
+    else:
+        max_num_args = num_args
+
+    return min_num_args, max_num_args
 
 
 def _extract_args(inner):

--- a/readme/macros.md
+++ b/readme/macros.md
@@ -79,14 +79,31 @@ Bear in mind that anti-cheat software might detect macros in games.
 > long as the key is pressed down.
 >
 > ```c#
-> hold(macro: Macro | str)
+> hold(macro: Macro)
 > ```
 >
 > Examples:
 >
 > ```c#
-> hold(KEY_A)
 > hold(key(space))
+> ```
+
+### hold_keys
+
+> Holds down all the provided symbols like a combination.
+>
+> An arbitrary number of symbols can be provided.
+>
+> ```c#
+> hold(*symbols: str)
+> ```
+>
+> Examples:
+>
+> ```c#
+> hold_keys(KEY_LEFTCTRL, KEY_A)
+> hold_keys(Control_L, Alt_L, Delete)
+> set(foo, KEY_A).hold_keys($foo)
 > ```
 
 ### mouse

--- a/readme/macros.md
+++ b/readme/macros.md
@@ -95,7 +95,7 @@ Bear in mind that anti-cheat software might detect macros in games.
 > An arbitrary number of symbols can be provided.
 >
 > ```c#
-> hold(*symbols: str)
+> hold_keys(*symbols: str)
 > ```
 >
 > Examples:

--- a/tests/integration/test_daemon.py
+++ b/tests/integration/test_daemon.py
@@ -19,6 +19,8 @@
 # along with input-remapper.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from tests.test import is_service_running
+
 import os
 import multiprocessing
 import unittest
@@ -27,8 +29,6 @@ import time
 from gi.repository import Gtk
 
 from inputremapper.daemon import Daemon, BUS_NAME
-
-from tests.test import is_service_running
 
 
 def gtk_iteration():

--- a/tests/integration/test_numlock.py
+++ b/tests/integration/test_numlock.py
@@ -19,10 +19,11 @@
 # along with input-remapper.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from tests.test import quick_cleanup
+
 import unittest
 
 from inputremapper.injection.numlock import is_numlock_on, set_numlock, ensure_numlock
-from tests.test import quick_cleanup
 
 
 class TestNumlock(unittest.TestCase):

--- a/tests/test.py
+++ b/tests/test.py
@@ -19,7 +19,11 @@
 # along with input-remapper.  If not, see <https://www.gnu.org/licenses/>.
 
 
-"""Sets up inputremapper for the tests and runs them."""
+"""Sets up inputremapper for the tests and runs them.
+
+This module needs to be imported first in test files.
+"""
+
 import argparse
 import os
 import sys

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,1 +1,3 @@
 """Tests that don't require a complete linux desktop."""
+
+import tests.test

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -19,13 +19,13 @@
 # along with input-remapper.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from tests.test import quick_cleanup, tmp
+
 import os
 import unittest
 
 from inputremapper.configs.global_config import global_config
 from inputremapper.configs.paths import touch
-
-from tests.test import quick_cleanup, tmp
 
 
 class TestConfig(unittest.TestCase):

--- a/tests/unit/test_consumer_control.py
+++ b/tests/unit/test_consumer_control.py
@@ -19,6 +19,8 @@
 # along with input-remapper.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from tests.test import new_event, quick_cleanup
+
 import unittest
 import asyncio
 
@@ -36,8 +38,6 @@ from inputremapper.injection.consumers.consumer import Consumer
 from inputremapper.injection.consumers.keycode_mapper import KeycodeMapper
 from inputremapper.configs.system_mapping import system_mapping
 from inputremapper.injection.global_uinputs import global_uinputs
-
-from tests.test import new_event, quick_cleanup
 
 
 class ExampleConsumer(Consumer):

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -19,6 +19,8 @@
 # along with input-remapper.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from tests.test import quick_cleanup
+
 import unittest
 
 from inputremapper.injection.context import Context
@@ -26,7 +28,6 @@ from inputremapper.configs.preset import Preset
 from inputremapper.event_combination import EventCombination
 from inputremapper.configs.global_config import NONE, MOUSE, WHEEL, BUTTONS
 from inputremapper.configs.system_mapping import system_mapping
-from tests.test import quick_cleanup
 
 
 class TestContext(unittest.TestCase):

--- a/tests/unit/test_control.py
+++ b/tests/unit/test_control.py
@@ -22,6 +22,8 @@
 """Testing the input-remapper-control command"""
 
 
+from tests.test import quick_cleanup, tmp
+
 import os
 import time
 import unittest
@@ -36,8 +38,6 @@ from inputremapper.daemon import Daemon
 from inputremapper.configs.preset import Preset
 from inputremapper.configs.paths import get_preset_path
 from inputremapper.groups import groups
-
-from tests.test import quick_cleanup, tmp
 
 
 def import_control():

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -19,6 +19,16 @@
 # along with input-remapper.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from tests.test import (
+    cleanup,
+    uinput_write_history_pipe,
+    new_event,
+    push_events,
+    is_service_running,
+    fixtures,
+    tmp,
+)
+
 import os
 import unittest
 import time
@@ -38,16 +48,6 @@ from inputremapper.event_combination import EventCombination
 from inputremapper.configs.preset import Preset
 from inputremapper.injection.injector import STARTING, RUNNING, STOPPED, UNKNOWN
 from inputremapper.daemon import Daemon
-
-from tests.test import (
-    cleanup,
-    uinput_write_history_pipe,
-    new_event,
-    push_events,
-    is_service_running,
-    fixtures,
-    tmp,
-)
 
 
 check_output = subprocess.check_output

--- a/tests/unit/test_dev_utils.py
+++ b/tests/unit/test_dev_utils.py
@@ -19,6 +19,8 @@
 # along with input-remapper.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from tests.test import new_event, InputDevice, MAX_ABS, MIN_ABS
+
 import unittest
 
 from evdev import ecodes
@@ -36,8 +38,6 @@ from evdev.ecodes import (
 from inputremapper.configs.global_config import global_config, BUTTONS
 from inputremapper.configs.preset import Preset
 from inputremapper import utils
-
-from tests.test import new_event, InputDevice, MAX_ABS, MIN_ABS
 
 
 class TestDevUtils(unittest.TestCase):

--- a/tests/unit/test_event_producer.py
+++ b/tests/unit/test_event_producer.py
@@ -19,7 +19,6 @@
 # along with input-remapper.  If not, see <https://www.gnu.org/licenses/>.
 
 
-
 from tests.test import (
     InputDevice,
     UInput,

--- a/tests/unit/test_event_producer.py
+++ b/tests/unit/test_event_producer.py
@@ -19,6 +19,18 @@
 # along with input-remapper.  If not, see <https://www.gnu.org/licenses/>.
 
 
+
+from tests.test import (
+    InputDevice,
+    UInput,
+    MAX_ABS,
+    clear_write_history,
+    uinput_write_history,
+    quick_cleanup,
+    new_event,
+    MIN_ABS,
+)
+
 import unittest
 import asyncio
 
@@ -42,17 +54,6 @@ from inputremapper.injection.consumers.joystick_to_mouse import (
     JoystickToMouse,
     MOUSE,
     WHEEL,
-)
-
-from tests.test import (
-    InputDevice,
-    UInput,
-    MAX_ABS,
-    clear_write_history,
-    uinput_write_history,
-    quick_cleanup,
-    new_event,
-    MIN_ABS,
 )
 
 

--- a/tests/unit/test_global_uinputs.py
+++ b/tests/unit/test_global_uinputs.py
@@ -19,6 +19,8 @@
 # along with input-remapper.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from tests.test import cleanup
+
 import sys
 import unittest
 import evdev
@@ -30,7 +32,6 @@ from evdev.ecodes import (
     KEY_A,
     ABS_X,
 )
-from tests.test import cleanup
 
 from inputremapper.injection.global_uinputs import (
     global_uinputs,

--- a/tests/unit/test_groups.py
+++ b/tests/unit/test_groups.py
@@ -19,6 +19,8 @@
 # along with input-remapper.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from tests.test import quick_cleanup, fixtures
+
 import os
 import unittest
 import json
@@ -39,8 +41,6 @@ from inputremapper.groups import (
     KEYBOARD,
     _Group,
 )
-
-from tests.test import quick_cleanup, fixtures
 
 
 class FakePipe:

--- a/tests/unit/test_injector.py
+++ b/tests/unit/test_injector.py
@@ -19,6 +19,21 @@
 # along with input-remapper.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from tests.test import (
+    new_event,
+    push_events,
+    fixtures,
+    EVENT_READ_TIMEOUT,
+    uinput_write_history_pipe,
+    MAX_ABS,
+    quick_cleanup,
+    read_write_history_pipe,
+    InputDevice,
+    uinputs,
+    keyboard_keys,
+    MIN_ABS,
+)
+
 import unittest
 from unittest import mock
 import time
@@ -67,21 +82,6 @@ from inputremapper.event_combination import EventCombination
 from inputremapper.injection.macros.parse import parse
 from inputremapper.injection.context import Context
 from inputremapper.groups import groups, classify, GAMEPAD
-
-from tests.test import (
-    new_event,
-    push_events,
-    fixtures,
-    EVENT_READ_TIMEOUT,
-    uinput_write_history_pipe,
-    MAX_ABS,
-    quick_cleanup,
-    read_write_history_pipe,
-    InputDevice,
-    uinputs,
-    keyboard_keys,
-    MIN_ABS,
-)
 
 
 def wait_for_uinput_write():

--- a/tests/unit/test_ipc.py
+++ b/tests/unit/test_ipc.py
@@ -19,6 +19,8 @@
 # along with input-remapper.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from tests.test import quick_cleanup, tmp
+
 import unittest
 import select
 import time
@@ -27,8 +29,6 @@ import os
 from inputremapper.ipc.pipe import Pipe
 from inputremapper.ipc.shared_dict import SharedDict
 from inputremapper.ipc.socket import Server, Client, Base
-
-from tests.test import quick_cleanup, tmp
 
 
 class TestSharedDict(unittest.TestCase):

--- a/tests/unit/test_keycode_mapper.py
+++ b/tests/unit/test_keycode_mapper.py
@@ -19,6 +19,16 @@
 # along with input-remapper.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from tests.test import (
+    new_event,
+    UInput,
+    uinput_write_history,
+    quick_cleanup,
+    InputDevice,
+    MAX_ABS,
+    MIN_ABS,
+)
+
 import unittest
 import asyncio
 import time
@@ -52,16 +62,6 @@ from inputremapper.configs.global_config import global_config, BUTTONS
 from inputremapper.configs.preset import Preset
 from inputremapper.configs.system_mapping import DISABLE_CODE
 from inputremapper.injection.global_uinputs import global_uinputs
-
-from tests.test import (
-    new_event,
-    UInput,
-    uinput_write_history,
-    quick_cleanup,
-    InputDevice,
-    MAX_ABS,
-    MIN_ABS,
-)
 
 
 def wait(func, timeout=1.0):

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -19,6 +19,8 @@
 # along with input-remapper.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from tests.test import tmp
+
 import os
 import shutil
 import unittest
@@ -26,8 +28,6 @@ import logging
 
 from inputremapper.logger import logger, add_filehandler, update_verbosity, log_info
 from inputremapper.configs.paths import remove
-
-from tests.test import tmp
 
 
 class TestLogger(unittest.TestCase):

--- a/tests/unit/test_macros.py
+++ b/tests/unit/test_macros.py
@@ -564,6 +564,18 @@ class TestMacros(MacroTestBase):
             ]
         )
 
+    async def test_hold_variable(self):
+        code_a = system_mapping.get("a")
+        macro = parse("set(foo, a).hold($foo)", self.context)
+        await macro.run(self.handler)
+        self.assertListEqual(
+            self.result,
+            [
+                (EV_KEY, code_a, 1),
+                (EV_KEY, code_a, 0),
+            ]
+        )
+
     async def test_hold_keys(self):
         macro = parse("set(foo, b).hold_keys(a, $foo, c)", self.context)
         # press first

--- a/tests/unit/test_macros.py
+++ b/tests/unit/test_macros.py
@@ -19,6 +19,8 @@
 # along with input-remapper.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from tests.test import logger, quick_cleanup, new_event
+
 import time
 import unittest
 import re
@@ -65,8 +67,6 @@ from inputremapper.configs.global_config import global_config
 from inputremapper.configs.preset import Preset
 from inputremapper.configs.system_mapping import system_mapping
 from inputremapper.utils import PRESS, RELEASE
-
-from tests.test import logger, quick_cleanup, new_event
 
 
 class MacroTestBase(unittest.IsolatedAsyncioTestCase):

--- a/tests/unit/test_macros.py
+++ b/tests/unit/test_macros.py
@@ -543,7 +543,7 @@ class TestMacros(MacroTestBase):
                 (EV_KEY, code_b, 0),
                 (EV_KEY, code_a, 1),
                 (EV_KEY, code_a, 0),
-            ]
+            ],
         )
 
     async def test_modify(self):
@@ -561,7 +561,7 @@ class TestMacros(MacroTestBase):
                 (EV_KEY, code_c, 0),
                 (EV_KEY, code_a, 0),
                 (EV_KEY, code_b, 0),
-            ]
+            ],
         )
 
     async def test_hold_variable(self):
@@ -573,7 +573,7 @@ class TestMacros(MacroTestBase):
             [
                 (EV_KEY, code_a, 1),
                 (EV_KEY, code_a, 0),
-            ]
+            ],
         )
 
     async def test_hold_keys(self):

--- a/tests/unit/test_migrations.py
+++ b/tests/unit/test_migrations.py
@@ -13,6 +13,8 @@
 # along with input-remapper.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from tests.test import quick_cleanup, tmp
+
 import os
 import unittest
 import shutil
@@ -28,8 +30,6 @@ from inputremapper.event_combination import EventCombination
 from inputremapper.user import HOME
 
 from inputremapper.logger import VERSION
-
-from tests.test import quick_cleanup, tmp
 
 
 class TestMigrations(unittest.TestCase):

--- a/tests/unit/test_migrations.py
+++ b/tests/unit/test_migrations.py
@@ -162,7 +162,6 @@ class TestMigrations(unittest.TestCase):
         {(type, code): symbol} or {(type, code, value): symbol} should migrate to
         {(type, code, value): (symbol, "keyboard")}
         """
-
         path = os.path.join(tmp, "presets", "Foo Device", "test.json")
         os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, "w") as file:
@@ -188,8 +187,6 @@ class TestMigrations(unittest.TestCase):
         loaded = Preset()
         self.assertEqual(loaded.num_saved_keys, 0)
         loaded.load(get_preset_path("Foo Device", "test"))
-        self.assertEqual(len(loaded), 6)
-        self.assertEqual(loaded.num_saved_keys, 6)
 
         self.assertEqual(
             loaded.get_mapping(EventCombination([EV_KEY, 1, 1])),
@@ -220,6 +217,10 @@ class TestMigrations(unittest.TestCase):
             ),
             ("c", "keyboard"),
         )
+
+        print(loaded._mapping)
+        self.assertEqual(len(loaded), 6)
+        self.assertEqual(loaded.num_saved_keys, 6)
 
     def test_migrate_otherwise(self):
         path = os.path.join(tmp, "presets", "Foo Device", "test.json")

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -19,13 +19,13 @@
 # along with input-remapper.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from tests.test import quick_cleanup, tmp
+
 import os
 import unittest
 import tempfile
 
 from inputremapper.configs.paths import touch, mkdir, get_preset_path, get_config_path
-
-from tests.test import quick_cleanup, tmp
 
 
 def _raise(error):

--- a/tests/unit/test_preset.py
+++ b/tests/unit/test_preset.py
@@ -19,6 +19,8 @@
 # along with input-remapper.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from tests.test import tmp, quick_cleanup
+
 import os
 import unittest
 import json
@@ -32,8 +34,6 @@ from inputremapper.configs.system_mapping import SystemMapping, XMODMAP_FILENAME
 from inputremapper.configs.global_config import global_config
 from inputremapper.configs.paths import get_preset_path
 from inputremapper.event_combination import EventCombination
-
-from tests.test import tmp, quick_cleanup
 
 
 class TestSystemMapping(unittest.TestCase):

--- a/tests/unit/test_presets.py
+++ b/tests/unit/test_presets.py
@@ -19,6 +19,8 @@
 # along with input-remapper.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from tests.test import tmp
+
 import os
 import unittest
 import shutil
@@ -34,8 +36,6 @@ from inputremapper.configs.preset import (
 )
 from inputremapper.configs.paths import CONFIG_PATH, get_preset_path, touch
 from inputremapper.gui.active_preset import active_preset
-
-from tests.test import tmp
 
 
 def create_preset(group_name, name="new preset"):

--- a/tests/unit/test_reader.py
+++ b/tests/unit/test_reader.py
@@ -19,6 +19,16 @@
 # along with input-remapper.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from tests.test import (
+    new_event,
+    push_events,
+    send_event_to_reader,
+    EVENT_READ_TIMEOUT,
+    START_READING_DELAY,
+    quick_cleanup,
+    MAX_ABS,
+)
+
 import unittest
 from unittest import mock
 import time
@@ -46,16 +56,6 @@ from inputremapper.configs.global_config import BUTTONS, MOUSE
 from inputremapper.event_combination import EventCombination
 from inputremapper.gui.helper import RootHelper
 from inputremapper.groups import groups
-
-from tests.test import (
-    new_event,
-    push_events,
-    send_event_to_reader,
-    EVENT_READ_TIMEOUT,
-    START_READING_DELAY,
-    quick_cleanup,
-    MAX_ABS,
-)
 
 
 CODE_1 = 100

--- a/tests/unit/test_test.py
+++ b/tests/unit/test_test.py
@@ -19,6 +19,17 @@
 # along with input-remapper.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from tests.test import (
+    InputDevice,
+    quick_cleanup,
+    cleanup,
+    fixtures,
+    new_event,
+    push_events,
+    EVENT_READ_TIMEOUT,
+    START_READING_DELAY,
+)
+
 import os
 import unittest
 import time
@@ -30,17 +41,6 @@ from evdev.ecodes import EV_ABS, EV_KEY
 from inputremapper.groups import groups
 from inputremapper.gui.reader import reader
 from inputremapper.gui.helper import RootHelper
-
-from tests.test import (
-    InputDevice,
-    quick_cleanup,
-    cleanup,
-    fixtures,
-    new_event,
-    push_events,
-    EVENT_READ_TIMEOUT,
-    START_READING_DELAY,
-)
 
 
 class TestTest(unittest.TestCase):

--- a/tests/unit/test_user.py
+++ b/tests/unit/test_user.py
@@ -19,13 +19,13 @@
 # along with input-remapper.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from tests.test import quick_cleanup
+
 import os
 import unittest
 from unittest import mock
 
 from inputremapper.user import get_user, get_home
-
-from tests.test import quick_cleanup
 
 
 def _raise(error):


### PR DESCRIPTION
- added hold_keys
- fixed variable resolving for key, modify and hold
- removed deprecated capability-requirements construction for macros. It maybe might have been interesting for compile-time validation to check if the target can handle the macro, but for this case a better solution is probably to extend `_type_check_symbol` to get the target of the mapping. A migration depends on this, so I will first make a new release and bump the AUR package, and then merge this after a week. This will cause issues with migrating when people have macros that inject mouse buttons. I decided that maintainability (less bugs) is more important than that, sorry. The target in the dropdown will have to be set to "mouse" manually
- macros can have a variable number of arguments now. see add_hold_keys for an example
- removed macro-function-shorthands from parsing error messages
- moved test imports to the top of all test files, to make sure the patches are loaded before the original modules are imported