### PR TITLE
Not copying source.phys anymore

### DIFF
--- a/inputremapper/daemon.py
+++ b/inputremapper/daemon.py
@@ -419,6 +419,8 @@ class Daemon:
         preset : string
             The name of the preset
         """
+        logger.info('Request to start injecting for "%s"', group_key)
+
         self.refresh(group_key)
 
         if self.config_dir is None:

--- a/inputremapper/injection/injector.py
+++ b/inputremapper/injection/injector.py
@@ -331,7 +331,9 @@ class Injector(multiprocessing.Process):
             forward_to = evdev.UInput(
                 name=get_udev_name(source.name, "forwarded"),
                 events=self._copy_capabilities(source),
-                phys=source.phys,
+                # phys=source.phys,  # this leads to confusion. the appearance of an uinput with this "phys" property
+                # causes the udev rule to autoload for the original device, overwriting our previous attempts at
+                # starting an injection.
                 vendor=source.info.vendor,
                 product=source.info.product,
                 version=source.info.version,


### PR DESCRIPTION
caused https://github.com/sezanzeb/input-remapper/issues/322, because the appearance of the "forwarded" uinput triggered the udev rule, which then autoloaded the preset even though a different injection was started a second ago.