### PR TITLE
Instructing python-evdev upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ input-remapper is now part of [Debian Unstable](https://packages.debian.org/sid/
 
 ##### pip
 
-Dependencies from your distros repo: `python3-evdev`, `gtksourceview4`, `python3-devel`, `python3-pydantic`
+Dependencies: `python3-evdev` (>=1.3.0), `gtksourceview4`, `python3-devel`, `python3-pydantic`
 
 ```bash
 sudo pip uninstall key-mapper

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ input-remapper is now part of [Debian Unstable](https://packages.debian.org/sid/
 
 ##### pip
 
-Dependencies: `python3-evdev` (>=1.3.0), `gtksourceview4`, `python3-devel`, `python3-pydantic`
+Dependencies: `python3-evdev` ≥1.3.0, `gtksourceview4`, `python3-devel`, `python3-pydantic`
 
 ```bash
 sudo pip uninstall key-mapper

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Dependencies: `python3-evdev` ≥1.3.0, `gtksourceview4`, `python3-devel`, `pyth
 ```bash
 sudo pip install evdev -U  # If newest version not in distros repo
 sudo pip uninstall key-mapper
-sudo pip install --no-binary :all: git+https://github.com/sezanzeb/input-remapper.git
+sudo pip install --no-binary :all: git+https://github.com/sezanzeb/input-remapper.git  # no --user
 sudo systemctl enable input-remapper
 sudo systemctl restart input-remapper
 ```

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ input-remapper is now part of [Debian Unstable](https://packages.debian.org/sid/
 Dependencies: `python3-evdev` ≥1.3.0, `gtksourceview4`, `python3-devel`, `python3-pydantic`
 
 ```bash
-sudo pip install evdev  # to get the newest version of python-evdev
+sudo pip install evdev -U  # If newest version not in distros repo
 sudo pip uninstall key-mapper
 sudo pip install --no-binary :all: git+https://github.com/sezanzeb/input-remapper.git
 sudo systemctl enable input-remapper

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ input-remapper is now part of [Debian Unstable](https://packages.debian.org/sid/
 Dependencies: `python3-evdev` ≥1.3.0, `gtksourceview4`, `python3-devel`, `python3-pydantic`
 
 ```bash
+sudo pip install evdev  # to get the newest version of python-evdev
 sudo pip uninstall key-mapper
 sudo pip install --no-binary :all: git+https://github.com/sezanzeb/input-remapper.git
 sudo systemctl enable input-remapper

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ input-remapper is now part of [Debian Unstable](https://packages.debian.org/sid/
 Dependencies: `python3-evdev` ≥1.3.0, `gtksourceview4`, `python3-devel`, `python3-pydantic`
 
 ```bash
-sudo pip install evdev -U  # If newest version not in distros repo
+sudo pip install evdev -U # If newest version not in distros repo
 sudo pip uninstall key-mapper
-sudo pip install --no-binary :all: git+https://github.com/sezanzeb/input-remapper.git  # no --user
+sudo pip install --no-binary :all: git+https://github.com/sezanzeb/input-remapper.git # no --user
 sudo systemctl enable input-remapper
 sudo systemctl restart input-remapper
 ```

--- a/inputremapper/gui/user_interface.py
+++ b/inputremapper/gui/user_interface.py
@@ -58,7 +58,7 @@ from inputremapper.gui.editor.editor import Editor
 from inputremapper.event_combination import EventCombination
 from inputremapper.gui.reader import reader
 from inputremapper.gui.helper import is_helper_running
-from inputremapper.injection.injector import RUNNING, FAILED, NO_GRAB
+from inputremapper.injection.injector import RUNNING, FAILED, NO_GRAB, UPGRADE_EVDEV
 from inputremapper.daemon import Daemon
 from inputremapper.configs.global_config import global_config
 from inputremapper.injection.macros.parse import is_this_a_macro, parse
@@ -626,6 +626,14 @@ class UserInterface:
                 "Either another application is already grabbing it or "
                 "your preset doesn't contain anything that is sent by the "
                 "device.",
+            )
+            return False
+
+        if state == UPGRADE_EVDEV:
+            self.show_status(
+                CTX_ERROR,
+                "Upgrade python-evdev",
+                "Your python-evdev version is too old.",
             )
             return False
 

--- a/inputremapper/injection/injector.py
+++ b/inputremapper/injection/injector.py
@@ -345,7 +345,7 @@ class Injector(multiprocessing.Process):
                 )
             except TypeError as e:
                 if "input_props" in str(e):
-                    logger.error('Please upgrade your python-evdev version. Exiting')
+                    logger.error("Please upgrade your python-evdev version. Exiting")
                     self._msg_pipe[0].send(UPGRADE_EVDEV)
                     sys.exit(12)
 

--- a/inputremapper/injection/injector.py
+++ b/inputremapper/injection/injector.py
@@ -48,7 +48,6 @@ DEV_NAME = "input-remapper"
 
 # messages
 CLOSE = 0
-OK = 1
 UPGRADE_EVDEV = 7
 
 # states

--- a/inputremapper/injection/injector.py
+++ b/inputremapper/injection/injector.py
@@ -332,8 +332,9 @@ class Injector(multiprocessing.Process):
                 forward_to = evdev.UInput(
                     name=get_udev_name(source.name, "forwarded"),
                     events=self._copy_capabilities(source),
-                    # phys=source.phys,  # this leads to confusion. the appearance of an uinput with this "phys"
-                    # property causes the udev rule to autoload for the original device, overwriting our previous
+                    # phys=source.phys,  # this leads to confusion. the appearance of
+                    # an uinput with this "phys" property causes the udev rule to
+                    # autoload for the original device, overwriting our previous
                     # attempts at starting an injection.
                     vendor=source.info.vendor,
                     product=source.info.product,
@@ -343,6 +344,8 @@ class Injector(multiprocessing.Process):
                 )
             except TypeError as e:
                 if "input_props" in str(e):
+                    # UInput constructor doesn't support input_props and
+                    # source.input_props doesn't exist with old python-evdev versions.
                     logger.error("Please upgrade your python-evdev version. Exiting")
                     self._msg_pipe[0].send(UPGRADE_EVDEV)
                     sys.exit(12)

--- a/tests/unit/test_injector.py
+++ b/tests/unit/test_injector.py
@@ -129,27 +129,6 @@ class TestInjector(unittest.IsolatedAsyncioTestCase):
             if isinstance(consumer, JoystickToMouse)
         ][0]
 
-    def test_create_uinput(self):
-        # can create an uinput with an input_props argument,
-        # which is ignored if it fails
-        def patch(
-            events=None,
-            name="py-evdev-uinput",
-            vendor=0x1,
-            product=0x1,
-            version=0x1,
-            bustype=0x3,
-            devnode="/dev/uinput",
-            phys="py-evdev-uinput",
-        ):
-            # act like some outdated python-evdev version or something that doesn't
-            # support input_props
-            pass
-
-        with mock.patch.object(evdev, "UInput", patch):
-            # should not raise an error
-            create_uinput(input_props=[])
-
     def test_grab(self):
         # path is from the fixtures
         path = "/dev/input/event10"

--- a/tests/unit/test_injector.py
+++ b/tests/unit/test_injector.py
@@ -68,7 +68,6 @@ from inputremapper.injection.injector import (
     NO_GRAB,
     UNKNOWN,
     get_udev_name,
-    create_uinput,
 )
 from inputremapper.injection.numlock import is_numlock_on
 from inputremapper.configs.system_mapping import (


### PR DESCRIPTION
Reverts https://github.com/sezanzeb/input-remapper/pull/344 and https://github.com/sezanzeb/input-remapper/pull/341

Closes https://github.com/sezanzeb/input-remapper/issues/345

The python-evdev version was too old, it should be upgraded instead