### PR TITLE
Added installation guide for `fedora`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ sudo apt install ./dist/input-remapper-1.4.2.deb
 
 input-remapper is now part of [Debian Unstable](https://packages.debian.org/sid/input-remapper)
 
+##### Fedora
+
+On fedora, you should first install python dependecies via below command and then continue with pip installation!
+
+```bash
+sudo dnf install python3-evdev python3-devel gtksourceview4 python3-pydantic
+sudo dnf install python-pydbus
+sudo dnf install xmodmap
+```
+
 ##### pip
 
 Dependencies: `python3-evdev` ≥1.3.0, `gtksourceview4`, `python3-devel`, `python3-pydantic`


### PR DESCRIPTION
I had a lot of trouble installing this module on `fedora 35`. I couldn't install `evdev` using `sudo pip install evdev` due to some weird error. I ended up installing finding and installing these python packages and after installing them, your solution works just fine.