### PR TITLE
Add `RequiresMountsFor=/var/log` to systemd unit

### DIFF
--- a/data/input-remapper.service
+++ b/data/input-remapper.service
@@ -3,6 +3,7 @@ Description=Service to inject keycodes without the GUI application
 # dbus is required for ipc between gui and input-remapper-control
 Requires=dbus.service
 After=dbus.service
+RequiresMountsFor=/var/log
 
 [Service]
 Type=dbus


### PR DESCRIPTION
If anyone mounts `/var` from a separate filesystem, this will ensure that `/var/log/input-remapper-control` is not written before `/var`/ is mounted.