### PR TITLE
Hiding irrelevant permission denied error log

### DIFF
--- a/inputremapper/logger.py
+++ b/inputremapper/logger.py
@@ -298,20 +298,21 @@ def trim_logfile(log_path):
 
 def add_filehandler(log_path=LOG_PATH):
     """Clear the existing logfile and start logging to it."""
-    try:
-        log_path = os.path.expanduser(log_path)
-        os.makedirs(os.path.dirname(log_path), exist_ok=True)
-
-        if os.path.isdir(log_path):
-            # used to be a folder < 0.8.0
-            shutil.rmtree(log_path)
-
-        trim_logfile(log_path)
-
-        file_handler = logging.FileHandler(log_path)
-        file_handler.setFormatter(ColorfulFormatter())
-        logger.addHandler(file_handler)
-
-        logger.info('Starting logging to "%s"', log_path)
-    except PermissionError:
+    if not os.access(log_path, os.W_OK | os.R_OK):
         logger.debug('No permission to log to "%s"', log_path)
+        return
+
+    log_path = os.path.expanduser(log_path)
+    os.makedirs(os.path.dirname(log_path), exist_ok=True)
+
+    if os.path.isdir(log_path):
+        # used to be a folder < 0.8.0
+        shutil.rmtree(log_path)
+
+    trim_logfile(log_path)
+
+    file_handler = logging.FileHandler(log_path)
+    file_handler.setFormatter(ColorfulFormatter())
+    logger.addHandler(file_handler)
+
+    logger.info('Starting logging to "%s"', log_path)


### PR DESCRIPTION
Permission denied error was printed when running key-mapper-control commands, because it tried to log into /var/log. Caused by the permissionError being handled somewhere within and reaching a logger.error instead of the logger.debug at the end of add_filehandler