### PR TITLE
Improved check if system is completely booted

### DIFF
--- a/bin/input-remapper-control
+++ b/bin/input-remapper-control
@@ -178,7 +178,13 @@ def internals(options):
     os.system(cmd)
 
 
-def systemd_finished():
+def _num_logged_in_users():
+    """Check how many users are logged in."""
+    who = subprocess.run(['who'], stdout=subprocess.PIPE).stdout.decode()
+    return len([user for user in who.split('\n') if user.strip() != ""])
+
+
+def _systemd_finished():
     """Check if systemd finished booting."""
     try:
         systemd_analyze = subprocess.run(['systemd-analyze'], stdout=subprocess.PIPE)
@@ -188,6 +194,26 @@ def systemd_finished():
         return True
 
     if 'finished' in systemd_analyze.stdout.decode():
+        # it writes into stderr otherwise or something
+        return True
+
+    return False
+
+
+def boot_finished():
+    """Check if booting is completed."""
+    # Get as much information as needed to really safely determine if booting up is complete.
+    # - `who` returns an empty list on some system for security purposes
+    # - something might be broken and might make systemd_analyze fail:
+    #       Bootup is not yet finished (org.freedesktop.systemd1.Manager.FinishTimestampMonotonic=0).
+    #       Please try again later.
+    #       Hint: Use 'systemctl list-jobs' to see active jobs
+    if _systemd_finished():
+        logger.debug('Booting finished')
+        return True
+
+    if _num_logged_in_users() > 0:
+        logger.debug('User(s) logged in')
         return True
 
     return False
@@ -206,11 +232,11 @@ def main(options):
     logger.debug('Call for "%s"', sys.argv)
 
     from inputremapper.configs.paths import USER
-    boot_finished = systemd_finished()
+    boot_finished_ = boot_finished()
     is_root = USER == "root"
     is_autoload = options.command == AUTOLOAD
     config_dir_set = options.config_dir is not None
-    if is_autoload and not boot_finished and is_root and not config_dir_set:
+    if is_autoload and not boot_finished_ and is_root and not config_dir_set:
         # this is probably happening during boot time and got
         # triggered by udev. There is no need to try to inject anything if the
         # service doesn't know where to look for a config file. This avoids a lot


### PR DESCRIPTION
Because my (and therefore probably other peoples as well) system is broken and `systemd-analyze` prints

```
Bootup is not yet finished (org.freedesktop.systemd1.Manager.FinishTimestampMonotonic=0).
Please try again later.
Hint: Use 'systemctl list-jobs' to see active jobs
```