### PR TITLE
Improved logs for communication with the Helper

### DIFF
--- a/inputremapper/configs/paths.py
+++ b/inputremapper/configs/paths.py
@@ -36,6 +36,16 @@ def chown(path):
     except LookupError:
         # the users group was unknown in one case for whatever reason
         shutil.chown(path, user=USER)
+<<<<<<< Updated upstream
+=======
+    except PermissionError:
+        # let's skip it and hope for the best.
+        logger.warning(
+            "Failed to hand %s over to %s due to permission problems",
+            path,
+            USER,
+        )
+>>>>>>> Stashed changes
 
 
 def touch(path, log=True):

--- a/inputremapper/configs/paths.py
+++ b/inputremapper/configs/paths.py
@@ -36,16 +36,6 @@ def chown(path):
     except LookupError:
         # the users group was unknown in one case for whatever reason
         shutil.chown(path, user=USER)
-<<<<<<< Updated upstream
-=======
-    except PermissionError:
-        # let's skip it and hope for the best.
-        logger.warning(
-            "Failed to hand %s over to %s due to permission problems",
-            path,
-            USER,
-        )
->>>>>>> Stashed changes
 
 
 def touch(path, log=True):

--- a/inputremapper/gui/helper.py
+++ b/inputremapper/gui/helper.py
@@ -88,13 +88,17 @@ class RootHelper:
 
     def run(self):
         """Start doing stuff. Blocks."""
-        logger.debug("Waiting for commands")
+        logger.debug("Waiting for the first command")
+        # the reader will check for new commands later, once it is running
+        # it keeps running for one device or another.
+        select.select([self._commands], [], [])
 
-        while True:
+        # possibly an alternative to select:
+        """while True:
             if self._commands.poll():
                 break
 
-            time.sleep(0.1)
+            time.sleep(0.1)"""
 
         logger.debug("Starting mainloop")
         while True:
@@ -177,8 +181,8 @@ class RootHelper:
         while True:
             ready_fds = select.select(rlist, [], [])
             if len(ready_fds[0]) == 0:
-                # whatever, happens for sockets sometimes. Maybe the socket
-                # is closed and select has nothing to select from?
+                # happens with sockets sometimes. Sockets are not stable and
+                # not used, so nothing to worry about now.
                 continue
 
             for fd in ready_fds[0]:

--- a/inputremapper/gui/helper.py
+++ b/inputremapper/gui/helper.py
@@ -37,6 +37,7 @@ import sys
 import select
 import multiprocessing
 import subprocess
+import time
 
 import evdev
 from evdev.ecodes import EV_KEY, EV_ABS
@@ -87,17 +88,22 @@ class RootHelper:
 
     def run(self):
         """Start doing stuff. Blocks."""
-        logger.debug('Waiting for commands')
-        select.select([self._commands], [], [])
+        logger.debug("Waiting for commands")
 
-        logger.debug('Starting mainloop')
+        while True:
+            if self._commands.poll():
+                break
+
+            time.sleep(0.1)
+
+        logger.debug("Starting mainloop")
         while True:
             self._read_commands()
             self._start_reading()
 
     def _send_groups(self):
         """Send the groups to the gui."""
-        logger.debug('Sending groups')
+        logger.debug("Sending groups")
         self._results.send({"type": MSG_GROUPS, "message": groups.dumps()})
 
     def _read_commands(self):
@@ -126,7 +132,7 @@ class RootHelper:
 
             logger.error('Received unknown command "%s"', cmd)
 
-        logger.debug('No more commands in pipe')
+        logger.debug("No more commands in pipe")
 
     def _start_reading(self):
         """Tell the evdev lib to start looking for keycodes.
@@ -180,7 +186,7 @@ class RootHelper:
                     # all commands will cause the reader to start over
                     # (possibly for a different device).
                     # _read_commands will check what is going on
-                    logger.debug('Stops reading due to new command')
+                    logger.debug("Stops reading due to new command")
                     return
 
                 device = rlist[fd]

--- a/inputremapper/gui/helper.py
+++ b/inputremapper/gui/helper.py
@@ -87,12 +87,14 @@ class RootHelper:
 
     def run(self):
         """Start doing stuff. Blocks."""
+        logger.debug('Starting mainloop')
         while True:
             self._handle_commands()
             self._start_reading()
 
     def _send_groups(self):
         """Send the groups to the gui."""
+        logger.debug('Sending groups')
         self._results.send({"type": MSG_GROUPS, "message": groups.dumps()})
 
     def _handle_commands(self):

--- a/tests/integration/test_gui.py
+++ b/tests/integration/test_gui.py
@@ -429,8 +429,7 @@ class GuiTestBase(unittest.TestCase):
         # the recording toggle connects to focus events
         self.set_focus(self.toggle)
         self.toggle.set_active(True)
-        gtk_iteration()
-        gtk_iteration()
+        self.throttle()
         self.assertIsNone(selection_label.get_combination())
         self.assertEqual(self.toggle.get_label(), "Press Key")
 
@@ -445,6 +444,9 @@ class GuiTestBase(unittest.TestCase):
             # make the window consume the keycode
             self.sleep(len(key))
 
+            # and some extra time for gtk to work at all
+            self.throttle()
+
             # holding down
             self.assertIsNotNone(reader.get_unreleased_keys())
             self.assertGreater(len(reader.get_unreleased_keys()), 0)
@@ -457,6 +459,9 @@ class GuiTestBase(unittest.TestCase):
 
             # wait for the window to consume the keycode
             self.sleep(len(key))
+
+            # ...and even more extra time for gtk
+            self.throttle()
 
             # released
             self.assertIsNone(reader.get_unreleased_keys())

--- a/tests/integration/test_gui.py
+++ b/tests/integration/test_gui.py
@@ -509,7 +509,7 @@ class GuiTestBase(unittest.TestCase):
         self.assertEqual(self.editor.get_symbol_input_text(), correct_case)
         self.assertFalse(active_preset.has_unsaved_changes())
 
-        # TODO I forgot what this is about
+        # TODO I forgot what this is about. Maybe to trigger saving?
         self.set_focus(self.editor.get_text_input())
         self.set_focus(None)
 

--- a/tests/integration/test_gui.py
+++ b/tests/integration/test_gui.py
@@ -509,6 +509,7 @@ class GuiTestBase(unittest.TestCase):
         self.assertEqual(self.editor.get_symbol_input_text(), correct_case)
         self.assertFalse(active_preset.has_unsaved_changes())
 
+        # TODO I forgot what this is about
         self.set_focus(self.editor.get_text_input())
         self.set_focus(None)
 

--- a/tests/integration/test_gui.py
+++ b/tests/integration/test_gui.py
@@ -324,9 +324,10 @@ class GuiTestBase(unittest.TestCase):
 
     def throttle(self):
         """Give GTK some time to process everything."""
-        # tests suddenly started to freeze my computer up completely
-        # and tests started to fail. By using this (and by optimizing some
-        # redundant calls in the gui) it worked again.
+        # tests suddenly started to freeze my computer up completely and tests started
+        # to fail. By using this (and by optimizing some redundant calls in the gui) it
+        # worked again. EDIT: Might have been caused by my broken/bloated ssd. I'll
+        # keep it in some places, since it did make the tests more reliable after all.
         for _ in range(10):
             gtk_iteration()
             time.sleep(0.002)
@@ -351,8 +352,6 @@ class GuiTestBase(unittest.TestCase):
 
         self.user_interface.window.set_focus(widget)
 
-        # for whatever miraculous reason it suddenly takes time before gtk does
-        # anything, even for old code.
         self.throttle()
 
     def get_selection_labels(self):
@@ -406,8 +405,6 @@ class GuiTestBase(unittest.TestCase):
             "work" if expect_success else "fail",
         )
 
-        self.throttle()
-
         self.assertIsNone(reader.get_unreleased_keys())
 
         changed = active_preset.has_unsaved_changes()
@@ -429,7 +426,6 @@ class GuiTestBase(unittest.TestCase):
         # the recording toggle connects to focus events
         self.set_focus(self.toggle)
         self.toggle.set_active(True)
-        self.throttle()
         self.assertIsNone(selection_label.get_combination())
         self.assertEqual(self.toggle.get_label(), "Press Key")
 
@@ -444,9 +440,6 @@ class GuiTestBase(unittest.TestCase):
             # make the window consume the keycode
             self.sleep(len(key))
 
-            # and some extra time for gtk to work at all
-            self.throttle()
-
             # holding down
             self.assertIsNotNone(reader.get_unreleased_keys())
             self.assertGreater(len(reader.get_unreleased_keys()), 0)
@@ -459,9 +452,6 @@ class GuiTestBase(unittest.TestCase):
 
             # wait for the window to consume the keycode
             self.sleep(len(key))
-
-            # ...and even more extra time for gtk
-            self.throttle()
 
             # released
             self.assertIsNone(reader.get_unreleased_keys())

--- a/tests/integration/test_gui.py
+++ b/tests/integration/test_gui.py
@@ -351,10 +351,9 @@ class GuiTestBase(unittest.TestCase):
 
         self.user_interface.window.set_focus(widget)
 
-        # for whatever miraculous reason it suddenly takes 0.005s before gtk does
+        # for whatever miraculous reason it suddenly takes time before gtk does
         # anything, even for old code.
-        time.sleep(0.02)
-        gtk_iteration()
+        self.throttle()
 
     def get_selection_labels(self):
         return self.selection_label_listbox.get_children()


### PR DESCRIPTION
https://github.com/sezanzeb/input-remapper/issues/359

- added more debug logs
- avoids a redundant call to `select.select`
- less usage of `throttle`, since tests are running well now