### PR TITLE
`key_down` and `key_up` macros

### DIFF
--- a/inputremapper/injection/macros/macro.py
+++ b/inputremapper/injection/macros/macro.py
@@ -329,6 +329,32 @@ class Macro:
 
         self.tasks.append(task)
 
+    def add_key_down(self, symbol):
+        """Press the symbol."""
+        _type_check_symbol(symbol)
+
+        async def task(handler):
+            resolved_symbol = _resolve(symbol, [str])
+            code = _type_check_symbol(resolved_symbol)
+
+            resolved_code = _resolve(code, [int])
+            handler(EV_KEY, resolved_code, 1)
+
+        self.tasks.append(task)
+
+    def add_key_up(self, symbol):
+        """Release the symbol."""
+        _type_check_symbol(symbol)
+
+        async def task(handler):
+            resolved_symbol = _resolve(symbol, [str])
+            code = _type_check_symbol(resolved_symbol)
+
+            resolved_code = _resolve(code, [int])
+            handler(EV_KEY, resolved_code, 0)
+
+        self.tasks.append(task)
+
     def add_hold(self, macro=None):
         """Loops the execution until key release."""
         _type_check(macro, [Macro, str, None], "hold", 1)

--- a/inputremapper/injection/macros/parse.py
+++ b/inputremapper/injection/macros/parse.py
@@ -46,6 +46,8 @@ FUNCTIONS = {
     "modify": Macro.add_modify,
     "repeat": Macro.add_repeat,
     "key": Macro.add_key,
+    "key_down": Macro.add_key_down,
+    "key_up": Macro.add_key_up,
     "event": Macro.add_event,
     "wait": Macro.add_wait,
     "hold": Macro.add_hold,

--- a/readme/macros.md
+++ b/readme/macros.md
@@ -27,6 +27,22 @@ Bear in mind that anti-cheat software might detect macros in games.
 > key(b).key(space)
 > ```
 
+### key_down and key_up
+
+> Inject the press/down/1 and release/up/0 events individually with those macros.
+>
+> ```c#
+> key_down(symbol: str)
+> key_up(symbol: str)
+> ```
+>
+> Examples:
+>
+> ```c#
+> key_down(KEY_A)
+> key_up(KEY_B)
+> ```
+
 ### wait
 
 > Waits in milliseconds before continuing the macro
@@ -74,9 +90,6 @@ Bear in mind that anti-cheat software might detect macros in games.
 ### hold
 
 > Executes the child macro repeatedly as long as the key is pressed down.
->
-> If a symbol string like KEY_A is provided, it will hold down that symbol as
-> long as the key is pressed down.
 >
 > ```c#
 > hold(macro: Macro)

--- a/tests/unit/test_macros.py
+++ b/tests/unit/test_macros.py
@@ -546,6 +546,24 @@ class TestMacros(MacroTestBase):
             ],
         )
 
+    async def test_key_down_up(self):
+        code_a = system_mapping.get("a")
+        code_b = system_mapping.get("b")
+        macro = parse(
+            "set(foo, b).key_down($foo).key_up($foo).key_up(a).key_down(a)",
+            self.context,
+        )
+        await macro.run(self.handler)
+        self.assertListEqual(
+            self.result,
+            [
+                (EV_KEY, code_b, 1),
+                (EV_KEY, code_b, 0),
+                (EV_KEY, code_a, 0),
+                (EV_KEY, code_a, 1),
+            ],
+        )
+
     async def test_modify(self):
         code_a = system_mapping.get("a")
         code_b = system_mapping.get("b")


### PR DESCRIPTION
closes #388

Also see https://github.com/sezanzeb/input-remapper/issues/382#issuecomment-1116319803 and https://github.com/sezanzeb/input-remapper/issues/198#issuecomment-952040319