### PR TITLE
Improved macro exception handling, keystroke sleep cleanup

### DIFF
--- a/inputremapper/injection/consumers/keycode_mapper.py
+++ b/inputremapper/injection/consumers/keycode_mapper.py
@@ -393,6 +393,13 @@ class KeycodeMapper(Consumer):
 
         return key
 
+    async def run_macro(self, macro, target_uinput):
+        """Run the provided macro."""
+        try:
+            await macro.run(self.macro_write(target_uinput))
+        except Exception as e:
+            logger.error(f'Macro "%s" failed: %s', macro.code, e)
+
     def handle_keycode(self, event, action, forward=True):
         """Write mapped keycodes, forward unmapped ones and manage macros.
 
@@ -515,7 +522,7 @@ class KeycodeMapper(Consumer):
                 logger.debug_key(
                     key, "maps to macro (%s, %s)", macro.code, target_uinput
                 )
-                asyncio.ensure_future(macro.run(self.macro_write(target_uinput)))
+                asyncio.ensure_future(self.run_macro(macro, target_uinput))
                 return
 
             if key in self.context.key_to_code:

--- a/inputremapper/injection/macros/macro.py
+++ b/inputremapper/injection/macros/macro.py
@@ -496,8 +496,8 @@ class Macro:
         async def task(handler):
             resolved_speed = value * _resolve(speed, [int])
             while self.is_holding():
-                await asyncio.sleep(injection_throttle / 1000)
                 handler(EV_REL, code, resolved_speed)
+                await asyncio.sleep(injection_throttle / 1000)
 
         self.tasks.append(task)
 

--- a/inputremapper/injection/macros/macro.py
+++ b/inputremapper/injection/macros/macro.py
@@ -36,7 +36,6 @@ w(1000).m(Shift_L, r(2, k(a))).w(10).k(b): <1s> A A <10ms> b
 
 
 import asyncio
-import copy
 import re
 
 from evdev.ecodes import ecodes, EV_KEY, EV_REL, REL_X, REL_Y, REL_WHEEL, REL_HWHEEL
@@ -412,7 +411,6 @@ class Macro:
             handler(EV_KEY, code, 1)
             await self._keycode_pause()
             await macro.run(handler)
-            await self._keycode_pause()
             handler(EV_KEY, code, 0)
             await self._keycode_pause()
 
@@ -492,11 +490,14 @@ class Macro:
             "right": (REL_X, 1),
         }[direction.lower()]
 
+        # how long to pause in ms between the injection of mouse events
+        injection_throttle = 10
+
         async def task(handler):
             resolved_speed = value * _resolve(speed, [int])
             while self.is_holding():
                 handler(EV_REL, code, resolved_speed)
-                await self._keycode_pause()
+                await asyncio.sleep(injection_throttle / 1000)
 
         self.tasks.append(task)
 

--- a/inputremapper/injection/macros/macro.py
+++ b/inputremapper/injection/macros/macro.py
@@ -264,17 +264,17 @@ class Macro:
         self.keystroke_sleep_ms = self.context.preset.get("macros.keystroke_sleep_ms")
 
         self.running = True
-        for task in self.tasks:
-            try:
+
+        try:
+            for task in self.tasks:
                 coroutine = task(handler)
                 if asyncio.iscoroutine(coroutine):
                     await coroutine
-            except Exception as e:
-                logger.error(f'Macro "%s" failed: %s', self.code, e)
-                break
-
-        # done
-        self.running = False
+        except Exception as e:
+            raise
+        finally:
+            # done
+            self.running = False
 
     def press_trigger(self):
         """The user pressed the trigger key down."""
@@ -496,8 +496,8 @@ class Macro:
         async def task(handler):
             resolved_speed = value * _resolve(speed, [int])
             while self.is_holding():
-                handler(EV_REL, code, resolved_speed)
                 await asyncio.sleep(injection_throttle / 1000)
+                handler(EV_REL, code, resolved_speed)
 
         self.tasks.append(task)
 

--- a/tests/unit/test_keycode_mapper.py
+++ b/tests/unit/test_keycode_mapper.py
@@ -940,7 +940,9 @@ class TestKeycodeMapper(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(count_before, count_after)
 
     async def test_hold_failing_child(self):
-        # if a child macro fails, hold will not try to run it again
+        # if a child macro fails, hold will not try to run it again.
+        # The exception is properly propagated through both `hold`s and the macro
+        # stops. If the code is broken, this test might enter an infinite loop.
         code_a = 100
         keycode_mapper = self.setup_keycode_mapper(
             {"a": code_a},
@@ -954,11 +956,8 @@ class TestKeycodeMapper(unittest.IsolatedAsyncioTestCase):
             return f
 
         keycode_mapper.macro_write = macro_write
-
         await keycode_mapper.notify(new_event(EV_KEY, 1, 1))
-
         await asyncio.sleep(0.1)
-
         self.assertFalse(active_macros[(EV_KEY, 1)].running)
 
     async def test_filter_trigger_spam(self):

--- a/tests/unit/test_keycode_mapper.py
+++ b/tests/unit/test_keycode_mapper.py
@@ -939,6 +939,28 @@ class TestKeycodeMapper(unittest.IsolatedAsyncioTestCase):
         count_after = len(self.history)
         self.assertEqual(count_before, count_after)
 
+    async def test_hold_failing_child(self):
+        # if a child macro fails, hold will not try to run it again
+        code_a = 100
+        keycode_mapper = self.setup_keycode_mapper(
+            {"a": code_a},
+            {((EV_KEY, 1, 1),): "hold(hold(key(a)))"},
+        )
+
+        def macro_write(*args, **kwargs):
+            def f():
+                raise Exception("foo")
+
+            return f
+
+        keycode_mapper.macro_write = macro_write
+
+        await keycode_mapper.notify(new_event(EV_KEY, 1, 1))
+
+        await asyncio.sleep(0.1)
+
+        self.assertFalse(active_macros[(EV_KEY, 1)].running)
+
     async def test_filter_trigger_spam(self):
         # test_filter_duplicates
         trigger = (EV_KEY, BTN_TL)

--- a/tests/unit/test_macros.py
+++ b/tests/unit/test_macros.py
@@ -988,7 +988,7 @@ class TestMacros(MacroTestBase):
         try:
             # should timeout, because the previous event doesn't match the filter
             await asyncio.wait_for(
-                macro._wait_for_event(lambda e, a: e.value == 3), 0.1
+                macro._wait_for_event(lambda e, a: e.value == 3), 0.1,
             )
             raise AssertionError("Expected asyncio.TimeoutError")
         except asyncio.TimeoutError:
@@ -1009,10 +1009,12 @@ class TestMacros(MacroTestBase):
         # the first parameter for `repeat` requires an integer, not "foo",
         # which makes `repeat` throw
         macro = parse('set(a, "foo").repeat($a, key(KEY_A)).key(KEY_B)', self.context)
-        await macro.run(self.handler)
 
-        # .run() it will not throw because repeat() breaks, and it will properly set
-        # it to stopped
+        try:
+            await macro.run(self.handler)
+        except TypeError as e:
+            self.assertIn("foo", str(e))
+
         self.assertFalse(macro.running)
 
         # key(KEY_B) is not executed, the macro stops

--- a/tests/unit/test_macros.py
+++ b/tests/unit/test_macros.py
@@ -988,7 +988,8 @@ class TestMacros(MacroTestBase):
         try:
             # should timeout, because the previous event doesn't match the filter
             await asyncio.wait_for(
-                macro._wait_for_event(lambda e, a: e.value == 3), 0.1,
+                macro._wait_for_event(lambda e, a: e.value == 3),
+                0.1,
             )
             raise AssertionError("Expected asyncio.TimeoutError")
         except asyncio.TimeoutError:

--- a/tests/unit/test_migrations.py
+++ b/tests/unit/test_migrations.py
@@ -218,7 +218,6 @@ class TestMigrations(unittest.TestCase):
             ("c", "keyboard"),
         )
 
-        print(loaded._mapping)
         self.assertEqual(len(loaded), 6)
         self.assertEqual(loaded.num_saved_keys, 6)
 


### PR DESCRIPTION
- the sleep between mouse movement events is something different and should be constant
- removed redundant `_keycode_pause`
- when a child macro fails, the whole macro will stop now. This was needed because certain broken macros caused fast infinite loops that froze input-remapper.