### PR TITLE
Removed logging filehandlers

### DIFF
--- a/.github/ISSUE_TEMPLATE/autoloading-not-working.md
+++ b/.github/ISSUE_TEMPLATE/autoloading-not-working.md
@@ -9,16 +9,18 @@ assignees: ''
 
 Please install the newest version from source to see if the problem has already been solved.
 
-Share some logs please:
+**System Information and logs**
 
 1. `input-remapper-control --version`
 2. which linux distro (ubuntu 20.04, manjaro, etc.)
-3. `echo $XDG_SESSION_TYPE`
-4. which desktop environment (gnome, plasma, xfce4, etc.)
-5. `sudo ls -l /proc/1/exe`
+3. which desktop environment (gnome, plasma, xfce4, etc.)
+4. `sudo ls -l /proc/1/exe` to check if you are using systemd
+5. `cat ~/.config/input-remapper/config.json` to see if the "autoload" config is written correctly
+6. `systemctl status input-remapper -n 50` the service has to be running
 
-6. `cat ~/.config/input-remapper/config.json`
-7. `input-remapper-control --command hello`
-8. `systemctl status input-remapper -n 50`
-9. `sudo pkill -f input-remapper-service && sudo input-remapper-service -d & sleep 2 && input-remapper-control --command autoload`, are your keys mapped now?
-10. (while the previous command is still running) `sudo evtest` and search for a device suffixed by "mapped". Select it, does it report any events? Share the output.
+**Testing the setup**
+
+1. `input-remapper-control --command hello`
+2. `sudo pkill -f input-remapper-service && sudo input-remapper-service -d & sleep 2 && input-remapper-control --command autoload`, are your keys mapped now?
+3. (while the previous command is still running) `sudo evtest` and search for a device suffixed by "mapped". Select it, does it report any events? Share the output.
+4. `sudo udevadm control --log-priority=debug && sudo udevadm control --reload-rules && journalctl -f | grep input-remapper`, now plug in the device that should autoload

--- a/bin/input-remapper-control
+++ b/bin/input-remapper-control
@@ -27,7 +27,7 @@ import argparse
 import logging
 import subprocess
 
-from inputremapper.logger import logger, update_verbosity, log_info, add_filehandler
+from inputremapper.logger import logger, update_verbosity, log_info
 from inputremapper.configs.migrations import migrate
 from inputremapper.configs.global_config import global_config
 
@@ -222,8 +222,6 @@ def boot_finished():
 def main(options):
     if options.debug:
         update_verbosity(True)
-
-    add_filehandler('/var/log/input-remapper-control')
 
     if options.version:
         log_info()

--- a/bin/input-remapper-service
+++ b/bin/input-remapper-service
@@ -25,7 +25,7 @@
 import sys
 from argparse import ArgumentParser
 
-from inputremapper.logger import update_verbosity, log_info, add_filehandler
+from inputremapper.logger import update_verbosity, log_info
 
 
 if __name__ == '__main__':
@@ -46,7 +46,6 @@ if __name__ == '__main__':
     # import input-remapper stuff after setting the log verbosity
     from inputremapper.daemon import Daemon
 
-    add_filehandler()
     if not options.hide_info:
         log_info('input-remapper-service')
 

--- a/data/input-remapper.service
+++ b/data/input-remapper.service
@@ -3,7 +3,6 @@ Description=Service to inject keycodes without the GUI application
 # dbus is required for ipc between gui and input-remapper-control
 Requires=dbus.service
 After=dbus.service
-RequiresMountsFor=/var/log
 
 [Service]
 Type=dbus

--- a/inputremapper/configs/migrations.py
+++ b/inputremapper/configs/migrations.py
@@ -276,8 +276,7 @@ def migrate():
     if v < pkg_resources.parse_version("1.4.1"):
         _otherwise_to_else()
 
-    if v < pkg_resources.parse_version("1.5.0"):
-        _remove_logs()
+    _remove_logs()
 
     # add new migrations here
 

--- a/inputremapper/configs/migrations.py
+++ b/inputremapper/configs/migrations.py
@@ -33,10 +33,10 @@ from evdev.ecodes import EV_KEY, EV_REL
 
 from inputremapper.logger import logger, VERSION
 from inputremapper.user import HOME
-from inputremapper.configs.paths import get_preset_path, mkdir, CONFIG_PATH
+from inputremapper.configs.paths import get_preset_path, mkdir, CONFIG_PATH, remove
 from inputremapper.configs.system_mapping import system_mapping
 from inputremapper.injection.global_uinputs import global_uinputs
-from inputremapper.injection.macros.parse import parse, is_this_a_macro
+from inputremapper.injection.macros.parse import is_this_a_macro
 
 
 def all_presets():
@@ -244,6 +244,18 @@ def _otherwise_to_else():
             file.write("\n")
 
 
+def _remove_logs():
+    """We will try to rely on journalctl for this in the future."""
+    try:
+        remove(f"{HOME}/.log/input-remapper")
+        remove("/var/log/input-remapper")
+        remove("/var/log/input-remapper-control")
+    except Exception as error:
+        logger.debug("Failed to remove deprecated logfiles: %s", str(error))
+        # this migration is not important. Continue
+        pass
+
+
 def migrate():
     """Migrate config files to the current release."""
     v = config_version()
@@ -263,6 +275,9 @@ def migrate():
 
     if v < pkg_resources.parse_version("1.4.1"):
         _otherwise_to_else()
+
+    if v < pkg_resources.parse_version("1.5.0"):
+        _remove_logs()
 
     # add new migrations here
 

--- a/inputremapper/logger.py
+++ b/inputremapper/logger.py
@@ -77,11 +77,6 @@ def debug_key(self, key, msg, *args):
 
 logging.Logger.debug_key = debug_key
 
-LOG_PATH = (
-    "/var/log/input-remapper"
-    if os.access("/var/log", os.W_OK)
-    else f"{HOME}/.log/input-remapper"
-)
 
 logger = logging.getLogger("input-remapper")
 
@@ -297,24 +292,3 @@ def trim_logfile(log_path):
         raise
     except Exception as e:
         logger.error('Failed to trim logfile: "%s"', str(e))
-
-
-def add_filehandler(log_path=LOG_PATH):
-    """Clear the existing logfile and start logging to it."""
-    try:
-        log_path = os.path.expanduser(log_path)
-        os.makedirs(os.path.dirname(log_path), exist_ok=True)
-
-        if os.path.isdir(log_path):
-            # used to be a folder < 0.8.0
-            shutil.rmtree(log_path)
-
-        trim_logfile(log_path)
-
-        file_handler = logging.FileHandler(log_path)
-        file_handler.setFormatter(ColorfulFormatter())
-        logger.addHandler(file_handler)
-
-        logger.info('Starting logging to "%s"', log_path)
-    except PermissionError:
-        logger.debug('No permission to log to "%s"', log_path)

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -31,22 +31,13 @@ from inputremapper.configs.paths import remove
 
 
 def add_filehandler(log_path):
-    """Clear the existing logfile and start logging to it."""
-    try:
-        log_path = os.path.expanduser(log_path)
-        os.makedirs(os.path.dirname(log_path), exist_ok=True)
-
-        if os.path.isdir(log_path):
-            # used to be a folder < 0.8.0
-            shutil.rmtree(log_path)
-
-        file_handler = logging.FileHandler(log_path)
-        file_handler.setFormatter(ColorfulFormatter())
-        logger.addHandler(file_handler)
-
-        logger.info('Starting logging to "%s"', log_path)
-    except PermissionError:
-        logger.debug('No permission to log to "%s"', log_path)
+    """Start logging to a file."""
+    log_path = os.path.expanduser(log_path)
+    os.makedirs(os.path.dirname(log_path), exist_ok=True)
+    file_handler = logging.FileHandler(log_path)
+    file_handler.setFormatter(ColorfulFormatter())
+    logger.addHandler(file_handler)
+    logger.info('Starting logging to "%s"', log_path)
 
 
 class TestLogger(unittest.TestCase):


### PR DESCRIPTION
- Journalctl should be used instead, see https://github.com/sezanzeb/input-remapper/pull/369#issuecomment-1107799124
- I never needed people to post contents from logfiles to fix problems

To get logs via journalctl during boot, write `udev_log="debug"` into `/etc/udev/udev.conf` (see https://blog.dachary.org/2016/11/30/logging-udev-events-at-boot-time/, https://askubuntu.com/questions/1190823/how-to-see-all-udev-events-during-boot)