### PR TITLE
Minor GUI Layout Improvements

### DIFF
--- a/data/input-remapper.glade
+++ b/data/input-remapper.glade
@@ -74,6 +74,33 @@
     <property name="can-focus">False</property>
     <property name="icon-name">list-add</property>
   </object>
+  <object class="GtkImage" id="image4">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">list-remove</property>
+  </object>
+  <object class="GtkImage" id="image5">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">dialog-cancel</property>
+  </object>
+  <object class="GtkImage" id="image6">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">dialog-ok</property>
+  </object>
+  <object class="GtkImage" id="new-icon">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="margin-right">2</property>
+    <property name="margin-end">2</property>
+    <property name="icon-name">document-new</property>
+  </object>
+  <object class="GtkImage" id="save-icon">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">document-save</property>
+  </object>
   <object class="GtkWindow" id="window">
     <property name="width-request">800</property>
     <property name="can-focus">False</property>
@@ -503,12 +530,31 @@ Gives your keys back their original function</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
                     <property name="image">image3</property>
-                    <property name="relief">none</property>
+                    <property name="always-show-image">True</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
                     <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="delete-mapping">
+                    <property name="label" translatable="yes">Delete Mapping</property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
+                    <property name="tooltip-text" translatable="yes">Delete this entry</property>
+                    <property name="image">icon-delete-row</property>
+                    <property name="always-show-image">True</property>
+                    <style>
+                      <class name="delete-mapping-button"/>
+                    </style>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
                   </packing>
                 </child>
               </object>
@@ -537,7 +583,7 @@ Gives your keys back their original function</property>
                 <property name="margin-top">18</property>
                 <property name="margin-bottom">18</property>
                 <property name="orientation">vertical</property>
-                <property name="spacing">12</property>
+                <property name="spacing">6</property>
                 <child>
                   <object class="GtkStackSwitcher">
                     <property name="visible">True</property>
@@ -597,6 +643,8 @@ Gives your keys back their original function</property>
                   <object class="GtkSeparator">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
+                    <property name="margin-top">12</property>
+                    <property name="margin-bottom">12</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -629,7 +677,6 @@ Gives your keys back their original function</property>
                       <object class="GtkLabel" id="combination-label">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="margin-bottom">8</property>
                         <property name="label" translatable="yes">no input configured</property>
                         <property name="wrap">True</property>
                       </object>
@@ -656,7 +703,6 @@ Gives your keys back their original function</property>
                     <property name="margin-start">18</property>
                     <property name="margin-end">18</property>
                     <property name="image">image2</property>
-                    <property name="relief">none</property>
                     <property name="always-show-image">True</property>
                   </object>
                   <packing>
@@ -674,7 +720,6 @@ Gives your keys back their original function</property>
                     <property name="margin-start">18</property>
                     <property name="margin-end">18</property>
                     <property name="image">image1</property>
-                    <property name="relief">none</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -966,24 +1011,7 @@ Gives your keys back their original function</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkButton" id="delete-mapping">
-                    <property name="label" translatable="yes">Delete Mapping</property>
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="receives-default">True</property>
-                    <property name="tooltip-text" translatable="yes">Delete this entry</property>
-                    <property name="image">icon-delete-row</property>
-                    <property name="relief">none</property>
-                    <property name="always-show-image">True</property>
-                    <style>
-                      <class name="delete-mapping-button"/>
-                    </style>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
+                  <placeholder/>
                 </child>
               </object>
               <packing>
@@ -1360,11 +1388,6 @@ Macros allow multiple characters to be written with a single key-press. Informat
       </object>
     </child>
   </object>
-  <object class="GtkImage" id="image4">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="icon-name">list-remove</property>
-  </object>
   <object class="GtkWindow" id="combination-editor">
     <property name="width-request">200</property>
     <property name="height-request">200</property>
@@ -1655,16 +1678,6 @@ Timeout:</property>
       </object>
     </child>
   </object>
-  <object class="GtkImage" id="image5">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="icon-name">dialog-cancel</property>
-  </object>
-  <object class="GtkImage" id="image6">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="icon-name">dialog-ok</property>
-  </object>
   <object class="GtkDialog" id="confirm-cancel">
     <property name="width-request">300</property>
     <property name="height-request">150</property>
@@ -1773,17 +1786,5 @@ Timeout:</property>
       <action-widget response="-6">button3</action-widget>
       <action-widget response="-3">button4</action-widget>
     </action-widgets>
-  </object>
-  <object class="GtkImage" id="new-icon">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="margin-right">2</property>
-    <property name="margin-end">2</property>
-    <property name="icon-name">document-new</property>
-  </object>
-  <object class="GtkImage" id="save-icon">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="icon-name">document-save</property>
   </object>
 </interface>

--- a/data/input-remapper.glade
+++ b/data/input-remapper.glade
@@ -1392,6 +1392,7 @@ Macros allow multiple characters to be written with a single key-press. Informat
     <property name="width-request">200</property>
     <property name="height-request">200</property>
     <property name="can-focus">False</property>
+    <property name="title" translatable="yes">Combination Editor</property>
     <property name="modal">True</property>
     <property name="window-position">center-on-parent</property>
     <property name="urgency-hint">True</property>
@@ -1405,7 +1406,7 @@ Macros allow multiple characters to be written with a single key-press. Informat
         <property name="margin-end">18</property>
         <property name="margin-top">18</property>
         <property name="margin-bottom">18</property>
-        <property name="spacing">12</property>
+        <property name="spacing">18</property>
         <child>
           <object class="GtkScrolledWindow">
             <property name="width-request">200</property>
@@ -1420,8 +1421,6 @@ Macros allow multiple characters to be written with a single key-press. Informat
                   <object class="GtkListBox" id="combination-listbox">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="margin-start">8</property>
-                    <property name="margin-end">8</property>
                     <property name="selection-mode">browse</property>
                   </object>
                 </child>
@@ -1492,16 +1491,28 @@ This can help when mapping a combination like Shift+A to map to a lowercase lett
               </packing>
             </child>
             <child>
-              <object class="GtkLabel">
+              <object class="GtkSeparator">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="margin-top">12</property>
-                <property name="label" translatable="yes">Event Specific</property>
+                <property name="margin-top">18</property>
+                <property name="margin-bottom">18</property>
               </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
                 <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Event Specific</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">3</property>
               </packing>
             </child>
             <child>
@@ -1541,7 +1552,7 @@ This can help when mapping a combination like Shift+A to map to a lowercase lett
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">3</property>
+                <property name="position">4</property>
               </packing>
             </child>
             <child>
@@ -1581,7 +1592,7 @@ This can not be used with key or macro mappings.</property>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">4</property>
+                <property name="position">5</property>
               </packing>
             </child>
             <child>
@@ -1625,7 +1636,7 @@ threshold:</property>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">5</property>
+                <property name="position">6</property>
               </packing>
             </child>
             <child>
@@ -1665,7 +1676,7 @@ Timeout:</property>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">6</property>
+                <property name="position">7</property>
               </packing>
             </child>
           </object>

--- a/data/input-remapper.glade
+++ b/data/input-remapper.glade
@@ -74,33 +74,6 @@
     <property name="can-focus">False</property>
     <property name="icon-name">list-add</property>
   </object>
-  <object class="GtkImage" id="image4">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="icon-name">list-remove</property>
-  </object>
-  <object class="GtkImage" id="image5">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="icon-name">dialog-cancel</property>
-  </object>
-  <object class="GtkImage" id="image6">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="icon-name">dialog-ok</property>
-  </object>
-  <object class="GtkImage" id="new-icon">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="margin-right">2</property>
-    <property name="margin-end">2</property>
-    <property name="icon-name">document-new</property>
-  </object>
-  <object class="GtkImage" id="save-icon">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="icon-name">document-save</property>
-  </object>
   <object class="GtkWindow" id="window">
     <property name="width-request">800</property>
     <property name="can-focus">False</property>
@@ -118,8 +91,6 @@
           <object class="GtkBox">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
-            <property name="margin-start">18</property>
-            <property name="margin-end">18</property>
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkMenuBar">
@@ -138,6 +109,8 @@
               <object class="GtkBox" id="devices">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
+                <property name="margin-start">18</property>
+                <property name="margin-end">18</property>
                 <property name="margin-bottom">18</property>
                 <property name="border-width">0</property>
                 <property name="spacing">12</property>
@@ -235,16 +208,13 @@ Gives your keys back their original function</property>
           <object class="GtkBox">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
-            <property name="margin-start">18</property>
-            <property name="margin-end">18</property>
-            <property name="margin-top">18</property>
-            <property name="margin-bottom">18</property>
-            <property name="spacing">6</property>
             <child>
               <!-- n-columns=2 n-rows=2 -->
               <object class="GtkGrid">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
+                <property name="margin-top">18</property>
+                <property name="margin-bottom">18</property>
                 <property name="row-spacing">6</property>
                 <property name="column-spacing">12</property>
                 <property name="row-homogeneous">True</property>
@@ -330,7 +300,19 @@ Gives your keys back their original function</property>
               <packing>
                 <property name="expand">True</property>
                 <property name="fill">True</property>
+                <property name="padding">18</property>
                 <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSeparator">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
               </packing>
             </child>
             <child>
@@ -338,7 +320,8 @@ Gives your keys back their original function</property>
               <object class="GtkGrid">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="margin-start">18</property>
+                <property name="margin-top">18</property>
+                <property name="margin-bottom">18</property>
                 <property name="row-spacing">6</property>
                 <property name="column-spacing">30</property>
                 <child>
@@ -407,44 +390,56 @@ Gives your keys back their original function</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkSwitch" id="preset_autoload_switch">
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="halign">start</property>
-                    <property name="valign">center</property>
-                  </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel">
+                  <object class="GtkBox">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="halign">end</property>
-                    <property name="valign">center</property>
-                    <property name="label" translatable="yes">Autoload:</property>
-                    <property name="xalign">0</property>
+                    <child>
+                      <object class="GtkSwitch" id="preset_autoload_switch">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="halign">start</property>
+                        <property name="valign">center</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-left">6</property>
+                        <property name="margin-start">6</property>
+                        <property name="label" translatable="yes">Autoload</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
                     <property name="left-attach">0</property>
                     <property name="top-attach">1</property>
+                    <property name="width">2</property>
                   </packing>
                 </child>
               </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">1</property>
+                <property name="padding">18</property>
+                <property name="position">2</property>
               </packing>
             </child>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="padding">4</property>
-            <property name="position">3</property>
+            <property name="position">2</property>
           </packing>
         </child>
         <child>
@@ -468,7 +463,7 @@ Gives your keys back their original function</property>
               <object class="GtkBox">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="margin-end">9</property>
+                <property name="margin-end">18</property>
                 <property name="margin-top">18</property>
                 <property name="margin-bottom">18</property>
                 <property name="orientation">vertical</property>
@@ -542,14 +537,14 @@ Gives your keys back their original function</property>
                 <property name="margin-top">18</property>
                 <property name="margin-bottom">18</property>
                 <property name="orientation">vertical</property>
-                <property name="spacing">6</property>
+                <property name="spacing">12</property>
                 <child>
                   <object class="GtkStackSwitcher">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="halign">center</property>
-                    <property name="margin-start">9</property>
-                    <property name="margin-end">9</property>
+                    <property name="margin-start">18</property>
+                    <property name="margin-end">18</property>
                     <property name="stack">editor-stack</property>
                   </object>
                   <packing>
@@ -562,8 +557,8 @@ Gives your keys back their original function</property>
                   <object class="GtkBox">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="margin-start">9</property>
-                    <property name="margin-end">9</property>
+                    <property name="margin-start">18</property>
+                    <property name="margin-end">18</property>
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkLabel">
@@ -602,8 +597,6 @@ Gives your keys back their original function</property>
                   <object class="GtkSeparator">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="margin-top">3</property>
-                    <property name="margin-bottom">3</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -615,8 +608,8 @@ Gives your keys back their original function</property>
                   <object class="GtkBox">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="margin-start">9</property>
-                    <property name="margin-end">9</property>
+                    <property name="margin-start">18</property>
+                    <property name="margin-end">18</property>
                     <property name="spacing">6</property>
                     <child>
                       <object class="GtkLabel">
@@ -636,7 +629,6 @@ Gives your keys back their original function</property>
                       <object class="GtkLabel" id="combination-label">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="margin-top">7</property>
                         <property name="margin-bottom">8</property>
                         <property name="label" translatable="yes">no input configured</property>
                         <property name="wrap">True</property>
@@ -661,6 +653,8 @@ Gives your keys back their original function</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
                     <property name="tooltip-text" translatable="yes">Record a button of your device that should be remapped</property>
+                    <property name="margin-start">18</property>
+                    <property name="margin-end">18</property>
                     <property name="image">image2</property>
                     <property name="relief">none</property>
                     <property name="always-show-image">True</property>
@@ -677,6 +671,8 @@ Gives your keys back their original function</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
+                    <property name="margin-start">18</property>
+                    <property name="margin-end">18</property>
                     <property name="image">image1</property>
                     <property name="relief">none</property>
                   </object>
@@ -708,8 +704,7 @@ Gives your keys back their original function</property>
               <object class="GtkBox">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="margin-start">9</property>
-                <property name="margin-end">9</property>
+                <property name="margin-start">18</property>
                 <property name="margin-top">18</property>
                 <property name="margin-bottom">18</property>
                 <property name="orientation">vertical</property>
@@ -758,8 +753,7 @@ Gives your keys back their original function</property>
                           <object class="GtkBox">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
-                            <property name="margin-start">9</property>
-                            <property name="margin-end">9</property>
+                            <property name="margin-end">12</property>
                             <property name="orientation">vertical</property>
                             <property name="spacing">6</property>
                             <child>
@@ -1366,6 +1360,11 @@ Macros allow multiple characters to be written with a single key-press. Informat
       </object>
     </child>
   </object>
+  <object class="GtkImage" id="image4">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">list-remove</property>
+  </object>
   <object class="GtkWindow" id="combination-editor">
     <property name="width-request">200</property>
     <property name="height-request">200</property>
@@ -1656,6 +1655,16 @@ Timeout:</property>
       </object>
     </child>
   </object>
+  <object class="GtkImage" id="image5">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">dialog-cancel</property>
+  </object>
+  <object class="GtkImage" id="image6">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">dialog-ok</property>
+  </object>
   <object class="GtkDialog" id="confirm-cancel">
     <property name="width-request">300</property>
     <property name="height-request">150</property>
@@ -1764,5 +1773,17 @@ Timeout:</property>
       <action-widget response="-6">button3</action-widget>
       <action-widget response="-3">button4</action-widget>
     </action-widgets>
+  </object>
+  <object class="GtkImage" id="new-icon">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="margin-right">2</property>
+    <property name="margin-end">2</property>
+    <property name="icon-name">document-new</property>
+  </object>
+  <object class="GtkImage" id="save-icon">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">document-save</property>
   </object>
 </interface>

--- a/inputremapper/gui/components.py
+++ b/inputremapper/gui/components.py
@@ -651,7 +651,7 @@ class ReleaseCombinationSwitch:
 
 
 class EventEntry(Gtk.ListBoxRow):
-    """the ListBoxRow representing a single event inside the CombinationListBox"""
+    """The ListBoxRow representing a single event inside the CombinationListBox."""
 
     __gtype_name__ = "EventEntry"
 
@@ -660,7 +660,9 @@ class EventEntry(Gtk.ListBoxRow):
 
         self.input_event = event
         self._controller = controller
+
         hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=4)
+        hbox.set_margin_start(12)
 
         label = Gtk.Label()
         label.set_label(event.description())
@@ -705,12 +707,12 @@ class EventEntry(Gtk.ListBoxRow):
         self._down_btn = down_btn
 
     def cleanup(self):
-        """remove any message listeners we are about to get destroyed"""
+        """Remove any message listeners we are about to get destroyed."""
         pass
 
 
 class CombinationListbox:
-    """the ListBox with all the events inside active_mapping.event_combination"""
+    """The ListBox with all the events inside active_mapping.event_combination."""
 
     def __init__(
         self,
@@ -723,10 +725,15 @@ class CombinationListbox:
         self._gui = listbox
         self._combination: Optional[EventCombination] = None
 
-        self._message_broker.subscribe(MessageType.mapping, self._on_mapping_changed)
         self._message_broker.subscribe(
-            MessageType.selected_event, self._on_event_changed
+            MessageType.mapping,
+            self._on_mapping_changed,
         )
+        self._message_broker.subscribe(
+            MessageType.selected_event,
+            self._on_event_changed,
+        )
+
         self._gui.connect("row-selected", self._on_gtk_row_selected)
 
     def _select_row(self, event: InputEvent):


### PR DESCRIPTION
before:

![Screenshot from 2022-07-23 13-02-26](https://user-images.githubusercontent.com/28510156/180602380-aec0d0dc-1174-400e-8cbb-a1bd3ca4c92b.png)

![Screenshot from 2022-07-23 13-02-14](https://user-images.githubusercontent.com/28510156/180602388-76bea1ac-c61a-402a-a368-a78627bf112f.png)

after:

![Screenshot from 2022-07-23 12-33-09](https://user-images.githubusercontent.com/28510156/180602396-c11283d3-f760-4521-944d-fca7ede4063a.png)

![Screenshot from 2022-07-23 13-02-51](https://user-images.githubusercontent.com/28510156/180602399-75073800-fee6-4023-99fe-a43068169616.png)

- changed title of combination editor
- increased spacings
- fixed space to the left and right of the device selection bar
- fixed dark borders in the combination editor list
- put separator between the buttons and the preset selection
- moved delete-mapping button below add-mapping button
- showing the "+" image of the add-mapping button
- put separator and space between "General" and "Event Specific"
- rearranged autoload switch and its label