### PR TITLE
Improved Test Fixtures

### DIFF
--- a/tests/integration/test_components.py
+++ b/tests/integration/test_components.py
@@ -4,18 +4,15 @@ from unittest.mock import MagicMock, patch
 
 import evdev
 from evdev.ecodes import EV_KEY, KEY_A, KEY_B, KEY_C
-
 import gi
-
-from inputremapper.input_event import InputEvent
 
 gi.require_version("Gtk", "3.0")
 gi.require_version("GLib", "2.0")
 gi.require_version("GtkSource", "4")
 from gi.repository import Gtk, GLib, GtkSource
 
-
 from tests.test import quick_cleanup, spy
+from inputremapper.input_event import InputEvent
 from inputremapper.gui.utils import CTX_ERROR, CTX_WARNING, gtk_iteration
 from inputremapper.gui.message_broker import (
     MessageBroker,

--- a/tests/test.py
+++ b/tests/test.py
@@ -195,6 +195,9 @@ class Fixture:
 
 
 class _Fixtures:
+    """contains all predefined Fixtures.
+    Can be extended with new Fixtures during runtime"""
+
     dev_input_event1 = Fixture(
         capabilities={
             evdev.ecodes.EV_KEY: [evdev.ecodes.KEY_A],
@@ -347,13 +350,14 @@ class _Fixtures:
         ]
         self._dynamic_fixtures = {}
 
-    def __getitem__(self, item: str) -> Fixture:
-        if fixture := self._dynamic_fixtures.get(item):
+    def __getitem__(self, path: str) -> Fixture:
+        """get a Fixture by it's unique /dev/input/eventX path"""
+        if fixture := self._dynamic_fixtures.get(path):
             return fixture
-        item = self._path_to_attribute(item)
+        path = self._path_to_attribute(path)
 
         try:
-            return getattr(self, item)
+            return getattr(self, path)
         except AttributeError as e:
             raise KeyError(str(e))
 
@@ -969,7 +973,9 @@ def prepare_presets():
     preset2.add(get_key_mapping(combination="1,4,1"))
     preset2.save()
 
-    time.sleep(0.1)  # make sure the timestamp of preset 3 is the newest
+    # make sure the timestamp of preset 3 is the newest,
+    # so that it will be automatically loaded by the GUI
+    time.sleep(0.1)
     preset3 = Preset(get_preset_path("Foo Device", "preset3"))
     preset3.add(get_key_mapping(combination="1,5,1"))
     preset3.save()

--- a/tests/unit/test_controller.py
+++ b/tests/unit/test_controller.py
@@ -115,10 +115,7 @@ class TestController(unittest.TestCase):
             "get_newest_group_key",
             MagicMock(side_effect=FileNotFoundError),
         ):
-            fixture_keys = [
-                fixture.get("group_key") or fixture.get("name")
-                for fixture in fixtures.values()
-            ]
+            fixture_keys = [fixture.group_key or fixture.name for fixture in fixtures]
             self.assertIn(self.controller.get_a_group(), fixture_keys)
 
     def test_should_get_newest_preset(self):

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -37,7 +37,7 @@ import subprocess
 import json
 
 import evdev
-from evdev.ecodes import EV_KEY, EV_ABS, KEY_B, KEY_A, ABS_X, BTN_A
+from evdev.ecodes import EV_KEY, EV_ABS, KEY_B, KEY_A, ABS_X, BTN_A, BTN_B
 from pydbus import SystemBus
 
 from inputremapper.configs.system_mapping import system_mapping
@@ -135,7 +135,7 @@ class TestDaemon(unittest.TestCase):
         """Injection 1"""
 
         # should forward the event unchanged
-        push_events(group.key, [new_event(EV_KEY, 13, 1)])
+        push_events(fixtures.gamepad, [new_event(EV_KEY, BTN_B, 1)])
 
         self.daemon = Daemon()
 
@@ -156,7 +156,7 @@ class TestDaemon(unittest.TestCase):
         event = uinput_write_history_pipe[0].recv()
         self.assertEqual(self.daemon.get_state(group.key), RUNNING)
         self.assertEqual(event.type, EV_KEY)
-        self.assertEqual(event.code, 13)
+        self.assertEqual(event.code, BTN_B)
         self.assertEqual(event.value, 1)
 
         self.daemon.stop_injecting(group.key)
@@ -175,7 +175,7 @@ class TestDaemon(unittest.TestCase):
 
         time.sleep(0.1)
         # -1234 will be classified as -1 by the injector
-        push_events(group.key, [new_event(*ev_2, -1234)])
+        push_events(fixtures.gamepad, [new_event(*ev_2, -1234)])
         time.sleep(0.1)
 
         self.assertTrue(uinput_write_history_pipe[0].poll())
@@ -227,7 +227,6 @@ class TestDaemon(unittest.TestCase):
 
         preset.save()
         global_config.set_autoload_preset(group_key, preset_name)
-        push_events(group_key, [new_event(*ev, 1)])
         self.daemon = Daemon()
 
         # make sure the devices are populated
@@ -240,7 +239,7 @@ class TestDaemon(unittest.TestCase):
             "info": evdev.device.DeviceInfo(4, 5, 6, 7),
             "name": group_name,
         }
-
+        push_events(fixtures[self.new_fixture_path], [new_event(*ev, 1)])
         self.daemon.start_injecting(group_key, preset_name)
 
         # test if the injector called groups.refresh successfully
@@ -304,7 +303,7 @@ class TestDaemon(unittest.TestCase):
 
         system_mapping.clear()
 
-        push_events(group.key, [new_event(*event)])
+        push_events(fixtures.bar_device, [new_event(*event)])
 
         # an existing config file is needed otherwise set_config_dir refuses
         # to use the directory

--- a/tests/unit/test_event_reader.py
+++ b/tests/unit/test_event_reader.py
@@ -74,7 +74,7 @@ class TestEventReader(unittest.IsolatedAsyncioTestCase):
         # won't care about the event, because the purpose is not set to BUTTON
         code_a = system_mapping.get("a")
         code_shift = system_mapping.get("KEY_LEFTSHIFT")
-        trigger = 1
+        trigger = evdev.ecodes.BTN_A
 
         self.preset.add(
             get_key_mapping(
@@ -117,9 +117,8 @@ class TestEventReader(unittest.IsolatedAsyncioTestCase):
             [
                 new_event(EV_KEY, trigger, 1),  # start the macro
                 new_event(EV_ABS, ABS_Y, 10),  # ignored
-                new_event(EV_KEY, 2, 2),  # ignored
-                new_event(EV_KEY, 2, 0),  # ignored
-                new_event(EV_REL, 1, 1),  # ignored
+                new_event(EV_KEY, evdev.ecodes.BTN_B, 2),  # ignored
+                new_event(EV_KEY, evdev.ecodes.BTN_B, 0),  # ignored
                 # stop it, the only way to trigger `then`
                 new_event(EV_KEY, trigger, 0),
             ]
@@ -138,7 +137,7 @@ class TestEventReader(unittest.IsolatedAsyncioTestCase):
         """Triggers then because the joystick events value is too low."""
         # TODO: Move this somewhere more sensible
         code_a = system_mapping.get("a")
-        trigger = 1
+        trigger = evdev.ecodes.BTN_A
         self.preset.add(
             get_key_mapping(
                 EventCombination([EV_KEY, trigger, 1]),

--- a/tests/unit/test_groups.py
+++ b/tests/unit/test_groups.py
@@ -19,7 +19,7 @@
 # along with input-remapper.  If not, see <https://www.gnu.org/licenses/>.
 
 
-from tests.test import quick_cleanup, fixtures
+from tests.test import quick_cleanup, fixtures, keyboard_keys
 
 import os
 import unittest
@@ -185,12 +185,17 @@ class TestGroups(unittest.TestCase):
         self.assertIsNone(groups.find(name="qux"))
 
         # verify this test even works at all
-        fixtures["/foo/bar"]["capabilities"][EV_KEY] = [KEY_A]
+        fixtures["/foo/bar"].capabilities[EV_KEY] = [KEY_A]
         groups.refresh()
         self.assertIsNotNone(groups.find(name="qux"))
 
     def test_duplicate_device(self):
-        fixtures["/dev/input/event20"]["name"] = "Foo Device"
+        fixtures["/dev/input/event100"] = {
+            "capabilities": {evdev.ecodes.EV_KEY: keyboard_keys},
+            "phys": "usb-0000:03:00.0-3/input1",
+            "info": evdev.device.DeviceInfo(2, 1, 2, 1),
+            "name": "Foo Device",
+        }
         groups.refresh()
 
         group1 = groups.find(key="Foo Device")
@@ -199,7 +204,7 @@ class TestGroups(unittest.TestCase):
 
         self.assertIn("/dev/input/event1", group1.paths)
         self.assertIn("/dev/input/event10", group2.paths)
-        self.assertIn("/dev/input/event20", group3.paths)
+        self.assertIn("/dev/input/event100", group3.paths)
 
         self.assertEqual(group1.key, "Foo Device")
         self.assertEqual(group2.key, "Foo Device 2")

--- a/tests/unit/test_injector.py
+++ b/tests/unit/test_injector.py
@@ -125,7 +125,7 @@ class TestInjector(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(gamepad)
         self.assertEqual(self.failed, 2)
         # success on the third try
-        self.assertEqual(device.name, fixtures[path]["name"])
+        self.assertEqual(device.name, fixtures[path].name)
 
     def test_fail_grab(self):
         self.make_it_fail = 999
@@ -313,7 +313,7 @@ class TestInjector(unittest.IsolatedAsyncioTestCase):
             )
 
         push_events(
-            "gamepad",
+            fixtures.gamepad,
             [
                 # should execute a macro...
                 new_event(EV_KEY, 8, 1),  # forwarded
@@ -328,6 +328,7 @@ class TestInjector(unittest.IsolatedAsyncioTestCase):
                 new_event(EV_KEY, 10, 0),
                 new_event(3124, 3564, 6542),
             ],
+            force=True,
         )
 
         self.injector = Injector(groups.find(name="gamepad"), preset)

--- a/tests/unit/test_test.py
+++ b/tests/unit/test_test.py
@@ -68,10 +68,9 @@ class TestTest(unittest.TestCase):
         self.assertIsInstance(capabilities[EV_KEY][0], int)
 
     def test_restore_fixtures(self):
-        fixtures[1] = [1234]
-        del fixtures["/dev/input/event11"]
+        fixtures["/bar/dev"] = {"name": "bla"}
         cleanup()
-        self.assertIsNone(fixtures.get(1))
+        self.assertIsNone(fixtures.get("/bar/dev"))
         self.assertIsNotNone(fixtures.get("/dev/input/event11"))
 
     def test_restore_os_environ(self):
@@ -115,7 +114,7 @@ class TestTest(unittest.TestCase):
         time.sleep(START_READING_DELAY)
 
         event = new_event(EV_KEY, 102, 1)
-        push_events("Foo Device 2", [event])
+        push_events(fixtures.foo_device_2_keyboard, [event])
         wait_for_results()
         self.assertTrue(reader._results.poll())
 
@@ -125,7 +124,7 @@ class TestTest(unittest.TestCase):
         # can push more events to the helper that is inside a separate
         # process, which end up being sent to the reader
         event = new_event(EV_KEY, 102, 0)
-        push_events("Foo Device 2", [event])
+        push_events(fixtures.foo_device_2_keyboard, [event])
         wait_for_results()
         self.assertTrue(reader._results.poll())
 


### PR DESCRIPTION
This allows us to specify the exact device to which a InputEvent is sent.
Previously it was only possible to specify the Group, which was limiting for some tests.