### PR TITLE
catching all exceptions

### DIFF
--- a/inputremapper/logger.py
+++ b/inputremapper/logger.py
@@ -213,7 +213,10 @@ EVDEV_VERSION = None
 try:
     VERSION = pkg_resources.require("input-remapper")[0].version
     EVDEV_VERSION = pkg_resources.require("evdev")[0].version
-except pkg_resources.DistributionNotFound as error:
+except Exception as error:
+    # there have been pkg_resources.DistributionNotFound and
+    # pkg_resources.ContextualVersionConflict errors so far.
+    # We can safely ignore all Exceptions here
     logger.info("Could not figure out the version")
     logger.debug(error)
 


### PR DESCRIPTION
Might fix #466

The problem there is apparently caused by an outdated version of typing-extensions. I guess we don't know yet if this actually matters for input-remapper.

In any case, we can safely ignore errors there and if the outdated package causes issues down the road, we will still get tracebacks later on.