### PR TITLE
Added ru_RU translation and adjusted ru text for policykit file

### DIFF
--- a/data/input-remapper.policy
+++ b/data/input-remapper.policy
@@ -8,6 +8,7 @@
         <description>Run Input Remapper as root</description>
         <message>Authentication is required to discover and read devices.</message>
 	<message xml:lang="sk">Vyžaduje sa prihlásenie na objavenie a prístup k zariadeniam.</message>
+	<message xml:lang="ru">Требуется аутентификация для обнаружения и чтения устройств.</message>
         <defaults>
             <allow_any>no</allow_any>
             <allow_inactive>auth_admin_keep</allow_inactive>

--- a/po/ru_RU.po
+++ b/po/ru_RU.po
@@ -1,0 +1,343 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-03-27 13:08+0200\n"
+"PO-Revision-Date: 2022-10-09 00:34+0200\n"
+"Last-Translator: Sviatoslav Vorona <jorrvaskr@rambler.ru>\n"
+"Language-Team: \n"
+"Language: ru_RU\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
+"X-Generator: Poedit 3.0\n"
+
+#: inputremapper/gui/editor/editor.py:608
+#, python-format
+msgid "\"%s\" already mapped to \"%s\""
+msgstr "\"%s\" уже привязан к \"%s\""
+
+#: inputremapper/gui/user_interface.py:609
+msgid ", CTRL + DEL to stop"
+msgstr ", CTRL + DEL чтобы остановить"
+
+#: data/input-remapper.glade:1070
+msgid "About"
+msgstr "О программе"
+
+#: inputremapper/gui/user_interface.py:606
+#, python-format
+msgid "Applied preset %s"
+msgstr "Применённая предустановка %s"
+
+#: inputremapper/gui/user_interface.py:427
+msgid "Applied the system default"
+msgstr "Применены системные настройки по умолчанию"
+
+#: data/input-remapper.glade:307
+msgid "Apply"
+msgstr "Применить"
+
+#: inputremapper/gui/user_interface.py:251
+#, python-format
+msgid "Are you sure to delete preset %s?"
+msgstr "Вы уверены что хотите удалить предустановку %s?"
+
+#: inputremapper/gui/editor/editor.py:545
+msgid "Are you sure to delete this mapping?"
+msgstr "Вы уверены что хотите удалить эту привязку?"
+
+#: data/input-remapper.glade:504
+msgid "Autoload"
+msgstr "Автозагрузка"
+
+#: data/input-remapper.glade:583 data/input-remapper.glade:627
+msgid "Buttons"
+msgstr "Кнопки"
+
+#: data/input-remapper.glade:65
+msgid "Cancel"
+msgstr "Отменить"
+
+#: inputremapper/gui/user_interface.py:524
+msgid "Cannot apply empty preset file"
+msgstr "Нельзя применить пустой файл предустановок"
+
+#: data/input-remapper.glade:860 inputremapper/gui/editor/editor.py:253
+msgid "Change Key"
+msgstr "Изменить клавишу"
+
+#: data/input-remapper.glade:326
+msgid "Copy"
+msgstr "Копировать"
+
+#: data/input-remapper.glade:350
+msgid "Create a new preset"
+msgstr "Создать новую предустановку"
+
+#: data/input-remapper.glade:365 data/input-remapper.glade:889
+msgid "Delete"
+msgstr "Удалить"
+
+#: data/input-remapper.glade:894
+msgid "Delete this entry"
+msgstr "Удалить эту запись"
+
+#: data/input-remapper.glade:370
+msgid "Delete this preset"
+msgstr "Удалить эту предустановку"
+
+#: data/input-remapper.glade:193
+msgid "Device"
+msgstr "Устройство"
+
+#: data/input-remapper.glade:331
+msgid "Duplicate this preset"
+msgstr "Скопировать эту предустановку"
+
+#: inputremapper/gui/user_interface.py:618
+#, python-format
+msgid "Failed to apply preset %s"
+msgstr "Не удалось применить предустановку %s"
+
+#: data/input-remapper.glade:239
+msgid "Help"
+msgstr "Помощь"
+
+#: data/input-remapper.glade:149
+msgid "Input Remapper"
+msgstr "Input Remapper"
+
+#: data/input-remapper.glade:584 data/input-remapper.glade:628
+msgid "Joystick"
+msgstr "Джойстик"
+
+#: data/input-remapper.glade:566
+msgid "Left joystick"
+msgstr "Левый джойстик"
+
+#: data/input-remapper.glade:581 data/input-remapper.glade:625
+msgid "Mouse"
+msgstr "Мышь"
+
+#: data/input-remapper.glade:654
+msgid "Mouse speed"
+msgstr "Скорость мыши"
+
+#: data/input-remapper.glade:345
+msgid "New"
+msgstr "Новая"
+
+#: inputremapper/gui/user_interface.py:689
+#: inputremapper/gui/user_interface.py:761
+msgid "Permission denied!"
+msgstr "Доступ запрещён!"
+
+#: data/input-remapper.glade:399
+msgid "Preset"
+msgstr "Предустановка"
+
+#: inputremapper/gui/editor/editor.py:249
+msgid "Press Key"
+msgstr "Нажмите клавишу"
+
+#: data/input-remapper.glade:864
+msgid "Record a button of your device that should be remapped"
+msgstr "Записать клавишу вашего устройства которая должна быть привязана"
+
+#: data/input-remapper.glade:438
+msgid "Rename"
+msgstr "Переименовать"
+
+#: data/input-remapper.glade:610
+msgid "Right joystick"
+msgstr "Правый джойстик"
+
+#: data/input-remapper.glade:469
+msgid "Save the entered name"
+msgstr "Сохранить введённое имя"
+
+#: data/input-remapper.glade:1098
+msgid ""
+"See <a href=\"https://github.com/sezanzeb/input-remapper/blob/HEAD/readme/"
+"usage.md\">usage.md</a> online on github for comprehensive information.\n"
+"\n"
+"A \"key + key + ... + key\" syntax can be used to trigger key combinations. "
+"For example \"Control_L + a\".\n"
+"\n"
+"Writing \"disable\" as a mapping disables a key.\n"
+"\n"
+"Macros allow multiple characters to be written with a single key-press. "
+"Information about programming them is available online on github. See <a "
+"href=\"https://github.com/sezanzeb/input-remapper/blob/HEAD/readme/macros."
+"md\">macros.md</a> and <a href=\"https://github.com/sezanzeb/input-remapper/"
+"blob/HEAD/readme/examples.md\">examples.md</a>"
+msgstr ""
+"Смотрите <a href=\"https://github.com/sezanzeb/input-remapper/blob/HEAD/"
+"readme/usage.md\">usage.md</a> в сети на github для исчерпывающей "
+"информации.\n"
+"\n"
+"A \"key + key + ... + key\" синтаксис может быть использован чтобы вызвать "
+"комбинацию клавиш. Например \"Control_L + a\".\n"
+"\n"
+"Написание \"disable\" как привязки отключает клавишу.\n"
+"\n"
+"Макросы позволяют написать множество символов нажатием одной клавиши. "
+"Информация об их программировании доступна в сети на github. Смотрите <a "
+"href=\"https://github.com/sezanzeb/input-remapper/blob/HEAD/readme/macros."
+"md\">macros.md</a> и <a href=\"https://github.com/sezanzeb/input-remapper/"
+"blob/HEAD/readme/examples.md\">examples.md</a>"
+
+#: inputremapper/gui/editor/editor.py:108
+msgid "Set the key first"
+msgstr "Сначала посмотреть клавишу"
+
+#: data/input-remapper.glade:221
+msgid ""
+"Shortcut: ctrl + del\n"
+"Gives your keys back their original function"
+msgstr ""
+"Комбинация: ctrl + del\n"
+"Возвращает ваши клавиши назад в исходную функцию"
+
+#: data/input-remapper.glade:1239
+msgid "Shortcuts"
+msgstr "Комбинации"
+
+#: data/input-remapper.glade:1141
+msgid ""
+"Shortcuts only work while keys are not being recorded and the gui is in "
+"focus."
+msgstr ""
+"Комбинации работают только пока клавиши не записываются и интерфейс "
+"приложения в фокусе."
+
+#: data/input-remapper.glade:312
+msgid "Start injecting. Don't hold down any keys while the injection starts"
+msgstr "Начать ввод. Не зажимайте никакие клавиши пока ввод запускается"
+
+#: inputremapper/gui/user_interface.py:567
+msgid "Starting injection..."
+msgstr "Запуск ввода..."
+
+#: data/input-remapper.glade:217
+msgid "Stop Injection"
+msgstr "Остановить привязку"
+
+#: inputremapper/gui/user_interface.py:481
+#, python-format
+msgid "Syntax error at %s, hover for info"
+msgstr "Синтаксическая ошибка в %s, наведите для информации"
+
+#: inputremapper/gui/user_interface.py:226
+msgid "The helper did not start"
+msgstr "Помощник не запустился"
+
+#: data/input-remapper.glade:879
+msgid "The type of device this mapping is emulating."
+msgstr "Тип устройства которое эмулируется этой привязкой."
+
+#: data/input-remapper.glade:499
+msgid "To automatically apply the preset after your login or when it connects."
+msgstr ""
+"Чтобы автоматически применить установку после входа в систему или "
+"присоединении устройства."
+
+#: inputremapper/gui/user_interface.py:779
+#, python-format
+msgid "Unknown mapping %s"
+msgstr "Неизвестная привязка %s"
+
+#: data/input-remapper.glade:1122
+msgid "Usage"
+msgstr "Использование"
+
+#: inputremapper/gui/editor/editor.py:519
+msgid "Use \"Stop Injection\" to stop before editing"
+msgstr ""
+"Используйте \"Остановить ввод\" чтобы остановиться перед редактированием"
+
+#: data/input-remapper.glade:1015
+msgid "Version unknown"
+msgstr "Неизвестная версия"
+
+#: data/input-remapper.glade:582 data/input-remapper.glade:626
+msgid "Wheel"
+msgstr "Колёсико"
+
+#: data/input-remapper.glade:1032
+msgid ""
+"You can find more information and report bugs at\n"
+"<a href=\"https://github.com/sezanzeb/input-remapper\">https://github.com/"
+"sezanzeb/input-remapper</a>"
+msgstr ""
+"Вы можете найти больше информации и сообщить о проблемах по адресу\n"
+"<a href=\"https://github.com/sezanzeb/input-remapper\">https://github.com/"
+"sezanzeb/input-remapper</a>"
+
+#: inputremapper/gui/user_interface.py:526
+msgid "You need to add keys and save first"
+msgstr "Вам необходимо сперва добавить клавиши и сохранить"
+
+#: inputremapper/gui/editor/editor.py:620
+msgid "Your system might reinterpret combinations "
+msgstr "Ваша система может истолковать комбинации иначе "
+
+#: inputremapper/gui/editor/editor.py:622
+msgid "break them."
+msgstr "нарушая их."
+
+#: data/input-remapper.glade:1173
+msgid "closes the application"
+msgstr "закрывает приложение"
+
+#: data/input-remapper.glade:1161
+msgid "ctrl + del"
+msgstr ""
+
+#: data/input-remapper.glade:1185
+msgid "ctrl + q"
+msgstr ""
+
+#: data/input-remapper.glade:1197
+msgid "ctrl + r"
+msgstr ""
+
+#: inputremapper/gui/editor/editor.py:619
+msgid "ctrl, alt and shift may not combine properly"
+msgstr "ctrl, alt и shift могут неправильно сочетаться"
+
+#: inputremapper/gui/editor/editor.py:78 inputremapper/gui/editor/editor.py:394
+msgid "new entry"
+msgstr "новая запись"
+
+#: data/input-remapper.glade:1209
+msgid "refreshes the device list"
+msgstr "обновляет список устройств"
+
+#: data/input-remapper.glade:1221
+msgid "stops the injection"
+msgstr "останавливает ввод"
+
+#: inputremapper/gui/editor/editor.py:621
+msgid "with those after they are injected, and by doing so "
+msgstr "с теми, которые после привязки, и тем самым "
+
+#: data/input-remapper.glade:1052
+msgid ""
+"© 2021 Sezanzeb proxima@sezanzeb.de\n"
+"This program comes with absolutely no warranty.\n"
+"See the <a href=\"https://www.gnu.org/licenses/gpl-3.0.html\">GNU General "
+"Public License, version 3 or later</a> for details."
+msgstr ""
+"© 2021 Sezanzeb proxima@sezanzeb.de\n"
+"Эта программа не включает никакой гарантии.\n"
+"Смотрите <a href=\"https://www.gnu.org/licenses/gpl-3.0.html\">GNU General "
+"Public License, version 3 or later</a> для большей информации."


### PR DESCRIPTION
Hello,

I've added **ru_RU** translation for **input-mapper**. Tested on my system and it works, though some distros specify **LANGUAGE** variable in a way there is only one letter group for the used language (for example, only **ru** instead of **ru_RU**). It looks like this:

`user@localhost ~ $ echo $LANGUAGE
ru:en_US
user@localhost ~ $`

I suggest you do the following changes - adjust the installation (or build) script in a way it creates a folder with a locale inside it and a directory symlink (sorry, I don't know much about installation, or build scripts for this application so I can't suggest more practical changes), like this:

```
user@localhost /usr/share/input-remapper/lang $ sudo ln -s ru_RU ru
user@localhost /usr/share/input-remapper/lang $ ls -l
total 16
drwxr-xr-x 3 root root 4096 окт  8 02:57 it_IT
lrwxrwxrwx 1 root root    5 окт  9 00:47 ru -> ru_RU
drwxr-xr-x 3 root root 4096 окт  8 22:53 ru_RU
drwxr-xr-x 3 root root 4096 окт  8 02:57 sk_SK
drwxr-xr-x 3 root root 4096 окт  8 02:57 zh_CN
user@localhost /usr/share/input-remapper/lang $
```

So it will pick up both if necessary and display translation anyway. Looks like an easy solution.

Thanks for your work by the way. Was able to adjust my Logitech MX Vertical just fine. The translation file was tested and it works:

![изображение](https://user-images.githubusercontent.com/115377018/194730402-4cfdf5fc-e963-4555-9d31-b9c44e08e1d2.png)
