### PR TITLE
reduced number of mapping parameters

### DIFF
--- a/inputremapper/configs/mapping.py
+++ b/inputremapper/configs/mapping.py
@@ -129,29 +129,43 @@ class UIMapping(BaseModel):
 
     # when mapping to relative axis
 
-    # frequency in Hz for REL_X/Y event generation
-    rel_xy_rate: PositiveInt = 60
-    # frequency in Hz for REL_WHEEL and REL_WHEEL_HI_RES event generation
-    rel_wheel_rate: PositiveInt = 60
+    # frequency in Hz for REL_ event generation
+    rel_rate: PositiveInt = 60
 
     # the base speed of the relative axis, compounds with the gain.
     # values are observed normal output values in evtest
-    rel_xy_speed: PositiveInt = 30
-    rel_wheel_speed: PositiveInt = 1
-    rel_wheel_hi_res_speed: PositiveInt = 120
+    rel_speed: PositiveInt = 30
 
     # when mapping from a relative axis:
     # the absolute value at which a EV_REL axis is considered at its maximum.
     # values are from evtest when moving the input quickly
-    rel_xy_max_input: PositiveInt = 100
-    rel_wheel_max_input: PositiveInt = 3
-    rel_wheel_hi_res_max_input: PositiveInt = 360
+    rel_input_cutoff: PositiveInt = 100
 
     # the time until a relative axis is considered stationary if no new events arrive
     release_timeout: PositiveFloat = 0.05
     # don't release immediately when a relative axis drops below the speed threshold
     # instead wait until it dropped for loger than release_timeout below the threshold
     force_release_timeout: bool = False
+
+    # special values for REL_WHEEL inputs and outputs. These try to provide good default
+    # values while keeping the number of configurable parameters low
+    @property
+    def rel_wheel_speed(self) -> int:
+        return max((1, self.rel_speed // 30))
+
+    @property
+    def rel_wheel_hi_res_speed(self) -> int:
+        # don't update this, update rel_wheel_speed instead
+        return self.rel_wheel_speed * 120
+
+    @property
+    def rel_wheel_max_input(self) -> int:
+        return max((1, self.rel_input_cutoff // 30))
+
+    @property
+    def rel_wheel_hi_res_max_input(self) -> int:
+        # don't update this, update rel_wheel_max_input instead
+        return self.rel_wheel_max_input * 120
 
     # callback which gets called if the event_combination is updated
     if not needs_workaround:

--- a/inputremapper/configs/mapping.py
+++ b/inputremapper/configs/mapping.py
@@ -64,6 +64,14 @@ needs_workaround = pkg_resources.parse_version(
 
 EMPTY_MAPPING_NAME = _("Empty Mapping")
 
+# Scaling factors for the wheel speed and input_cutoff. The mouse wheel has
+# different sensitivity than any other relative axis, so we scale the default values to
+# account for the different sensitivity.
+WHEEL_SCALING = 30
+# WHEEL_HI_RES always generates events with 120 times higher values than WHEEL
+# https://www.kernel.org/doc/html/latest/input/event-codes.html?highlight=wheel_hi_res#ev-rel
+WHEEL_HI_RES_SCALING = 120
+
 
 class KnownUinput(str, enum.Enum):
     keyboard = "keyboard"
@@ -151,21 +159,19 @@ class UIMapping(BaseModel):
     # values while keeping the number of configurable parameters low
     @property
     def rel_wheel_speed(self) -> int:
-        return max((1, self.rel_speed // 30))
+        return max((1, self.rel_speed // WHEEL_SCALING))
 
     @property
     def rel_wheel_hi_res_speed(self) -> int:
-        # don't update this, update rel_wheel_speed instead
-        return self.rel_wheel_speed * 120
+        return self.rel_wheel_speed * WHEEL_HI_RES_SCALING
 
     @property
     def rel_wheel_max_input(self) -> int:
-        return max((1, self.rel_input_cutoff // 30))
+        return max((1, self.rel_input_cutoff // WHEEL_SCALING))
 
     @property
     def rel_wheel_hi_res_max_input(self) -> int:
-        # don't update this, update rel_wheel_max_input instead
-        return self.rel_wheel_max_input * 120
+        return self.rel_wheel_max_input * WHEEL_HI_RES_SCALING
 
     # callback which gets called if the event_combination is updated
     if not needs_workaround:

--- a/inputremapper/gui/components/editor.py
+++ b/inputremapper/gui/components/editor.py
@@ -771,7 +771,7 @@ class ReleaseTimeoutInput:
 
 
 class RelativeInputCutoffInput:
-    """the number selector to set active_mapping.rel_xy_max_input"""
+    """the number selector to set active_mapping.rel_input_cutoff"""
 
     def __init__(
         self,
@@ -800,7 +800,7 @@ class RelativeInputCutoffInput:
             self._gui.set_opacity(0.5)
 
         with HandlerDisabled(self._gui, self._on_gtk_changed):
-            self._gui.set_value(mapping.rel_xy_max_input)
+            self._gui.set_value(mapping.rel_input_cutoff)
 
     def _on_gtk_changed(self, *_):
         self._controller.update_mapping(rel_xy_max_input=self._gui.get_value())

--- a/inputremapper/injection/macros/macro.py
+++ b/inputremapper/injection/macros/macro.py
@@ -494,7 +494,7 @@ class Macro:
             resolved_speed = value * _resolve(speed, [int])
             while self.is_holding():
                 handler(EV_REL, code, resolved_speed)
-                await asyncio.sleep(1 / self.mapping.rel_xy_rate)
+                await asyncio.sleep(1 / self.mapping.rel_rate)
 
         self.tasks.append(task)
 
@@ -519,7 +519,7 @@ class Macro:
                     remainder[i] = math.fmod(float_value, 1)
                     if abs(float_value) >= 1:
                         handler(EV_REL, code[i], int(float_value))
-                await asyncio.sleep(1 / self.mapping.rel_wheel_rate)
+                await asyncio.sleep(1 / self.mapping.rel_rate)
 
         self.tasks.append(task)
 

--- a/inputremapper/injection/mapping_handlers/abs_to_rel_handler.py
+++ b/inputremapper/injection/mapping_handlers/abs_to_rel_handler.py
@@ -49,7 +49,7 @@ from inputremapper.utils import get_evdev_constant_name
 
 async def _run_normal_output(self) -> None:
     """Start injecting events."""
-    weight = self.mapping.rel_xy_speed
+    weight = self.mapping.rel_speed
 
     self._running = True
     self._stop = False
@@ -65,7 +65,7 @@ async def _run_normal_output(self) -> None:
         self._write(EV_REL, self.mapping.output_code, value)
 
         time_taken = time.time() - start
-        await asyncio.sleep(max(0.0, (1 / self.mapping.rel_xy_rate) - time_taken))
+        await asyncio.sleep(max(0.0, (1 / self.mapping.rel_rate) - time_taken))
         start = time.time()
 
     # logger.debug("stopping AbsToRel loop")
@@ -98,7 +98,7 @@ async def _run_wheel_output(self, codes: Tuple[int, int]) -> None:
             self._write(EV_REL, codes[i], value)
 
         time_taken = time.time() - start
-        await asyncio.sleep(max(0.0, (1 / self.mapping.rel_wheel_rate) - time_taken))
+        await asyncio.sleep(max(0.0, (1 / self.mapping.rel_rate) - time_taken))
         start = time.time()
 
     # logger.debug("stopping AbsToRel loop")

--- a/inputremapper/injection/mapping_handlers/rel_to_abs_handler.py
+++ b/inputremapper/injection/mapping_handlers/rel_to_abs_handler.py
@@ -86,7 +86,7 @@ class RelToAbsHandler(MappingHandler):
         elif self._input_movement[1] in [REL_WHEEL_HI_RES, REL_HWHEEL_HI_RES]:
             max_ = mapping.rel_wheel_hi_res_max_input
         else:
-            max_ = mapping.rel_xy_max_input
+            max_ = mapping.rel_input_cutoff
 
         self._transform = Transformation(
             max_=max_,

--- a/inputremapper/injection/mapping_handlers/rel_to_btn_handler.py
+++ b/inputremapper/injection/mapping_handlers/rel_to_btn_handler.py
@@ -76,7 +76,7 @@ class RelToBtnHandler(MappingHandler):
 
     async def _stage_release(self, source, forward, suppress):
         while time.time() < self._last_activation + self.mapping.release_timeout:
-            await asyncio.sleep(1 / self.mapping.rel_xy_rate)
+            await asyncio.sleep(1 / self.mapping.rel_rate)
 
         if self._abort_release:
             self._abort_release = False

--- a/inputremapper/injection/mapping_handlers/rel_to_rel_handler.py
+++ b/inputremapper/injection/mapping_handlers/rel_to_rel_handler.py
@@ -90,7 +90,7 @@ class RelToRelHandler(MappingHandler):
 
     _wheel_remainder: Remainder
     _wheel_hi_res_remainder: Remainder
-    _default_remainder: Remainder
+    _xy_remainder: Remainder
 
     def __init__(
         self,
@@ -118,11 +118,11 @@ class RelToRelHandler(MappingHandler):
         elif self._input_event.is_wheel_hi_res_event:
             max_ = self.mapping.rel_wheel_hi_res_speed
         else:
-            max_ = self.mapping.rel_xy_speed
+            max_ = self.mapping.rel_speed
 
         self._wheel_remainder = Remainder(self.mapping.rel_wheel_speed)
         self._wheel_hi_res_remainder = Remainder(self.mapping.rel_wheel_hi_res_speed)
-        self._xy_remainder = Remainder(self.mapping.rel_xy_speed)
+        self._xy_remainder = Remainder(self.mapping.rel_speed)
 
         self._transform = Transformation(
             max_=max_,

--- a/tests/integration/test_components.py
+++ b/tests/integration/test_components.py
@@ -1354,7 +1354,7 @@ class TestRelativeInputCutoffInput(ComponentBaseTest):
             MappingData(
                 target_uinput="mouse",
                 event_combination="2,0,0",
-                rel_xy_max_input=50,
+                rel_input_cutoff=50,
                 output_type=3,
                 output_code=0,
             )
@@ -1373,7 +1373,7 @@ class TestRelativeInputCutoffInput(ComponentBaseTest):
             MappingData(
                 target_uinput="mouse",
                 event_combination="2,0,0",
-                rel_xy_max_input=200,
+                rel_input_cutoff=200,
                 output_type=3,
                 output_code=0,
             )
@@ -1385,7 +1385,7 @@ class TestRelativeInputCutoffInput(ComponentBaseTest):
             MappingData(
                 target_uinput="mouse",
                 event_combination="2,0,0",
-                rel_xy_max_input=200,
+                rel_input_cutoff=200,
                 output_type=3,
                 output_code=0,
             )
@@ -1416,7 +1416,7 @@ class TestRelativeInputCutoffInput(ComponentBaseTest):
             MappingData(
                 target_uinput="mouse",
                 event_combination="2,0,0",
-                rel_xy_max_input=200,
+                rel_input_cutoff=200,
                 output_type=2,
                 output_code=0,
             )
@@ -1437,7 +1437,7 @@ class TestRelativeInputCutoffInput(ComponentBaseTest):
             MappingData(
                 target_uinput="mouse",
                 event_combination="2,0,0",
-                rel_xy_max_input=50,
+                rel_input_cutoff=50,
                 output_type=3,
                 output_code=0,
             )

--- a/tests/unit/test_macros.py
+++ b/tests/unit/test_macros.py
@@ -116,8 +116,7 @@ class MacroTestBase(unittest.IsolatedAsyncioTestCase):
 
 class DummyMapping:
     macro_key_sleep_ms = 10
-    rel_xy_rate = 60
-    rel_wheel_rate = 60
+    rel_rate = 60
 
 
 class TestMacros(MacroTestBase):
@@ -974,7 +973,7 @@ class TestMacros(MacroTestBase):
         macro_2.release_trigger()
 
         self.assertIn((EV_REL, REL_Y, -4), self.result)
-        expected_wheel_hi_res_event_count = sleep * DummyMapping.rel_wheel_rate
+        expected_wheel_hi_res_event_count = sleep * DummyMapping.rel_rate
         expected_wheel_event_count = int(
             expected_wheel_hi_res_event_count / 120 * wheel_speed
         )

--- a/tests/unit/test_mapping.py
+++ b/tests/unit/test_mapping.py
@@ -62,11 +62,11 @@ class TestMapping(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(m.deadzone, 0.1)
         self.assertEqual(m.gain, 1)
         self.assertEqual(m.expo, 0)
-        self.assertEqual(m.rel_xy_rate, 60)
-        self.assertEqual(m.rel_wheel_rate, 60)
-        self.assertEqual(m.rel_xy_speed, 30)
+        self.assertEqual(m.rel_rate, 60)
+        self.assertEqual(m.rel_rate, 60)
+        self.assertEqual(m.rel_speed, 30)
         self.assertEqual(m.rel_wheel_speed, 1)
-        self.assertEqual(m.rel_xy_max_input, 100)
+        self.assertEqual(m.rel_input_cutoff, 100)
         self.assertEqual(m.release_timeout, 0.05)
 
     def test_is_wheel_output(self):
@@ -349,29 +349,23 @@ class TestMapping(unittest.IsolatedAsyncioTestCase):
         Mapping(**cfg, expo=-1)
 
         # negative rate
-        test(**cfg, rel_xy_rate=-1)
-        test(**cfg, rel_wheel_rate=-1)
+        test(**cfg, rel_rate=-1)
+        test(**cfg, rel_rate=0)
 
-        test(**cfg, rel_xy_rate=0)
-        test(**cfg, rel_wheel_rate=0)
+        Mapping(**cfg, rel_rate=1)
+        Mapping(**cfg, rel_rate=200)
 
-        Mapping(**cfg, rel_xy_rate=1)
-        Mapping(**cfg, rel_xy_rate=200)
+        # negative rel_speed
+        test(**cfg, rel_speed=-1)
+        test(**cfg, rel_speed=0)
+        Mapping(**cfg, rel_speed=1)
+        Mapping(**cfg, rel_speed=200)
 
-        Mapping(**cfg, rel_wheel_rate=1)
-        Mapping(**cfg, rel_wheel_rate=200)
-
-        # negative rel_xy_speed
-        test(**cfg, rel_xy_speed=-1)
-        test(**cfg, rel_xy_speed=0)
-        Mapping(**cfg, rel_xy_speed=1)
-        Mapping(**cfg, rel_xy_speed=200)
-
-        # negative rel_xy_max_input
-        test(**cfg, rel_xy_max_input=-1)
-        test(**cfg, rel_xy_max_input=0)
-        Mapping(**cfg, rel_xy_max_input=1)
-        Mapping(**cfg, rel_xy_max_input=200)
+        # negative rel_input_cutoff
+        test(**cfg, rel_input_cutoff=-1)
+        test(**cfg, rel_input_cutoff=0)
+        Mapping(**cfg, rel_input_cutoff=1)
+        Mapping(**cfg, rel_input_cutoff=200)
 
         # negative release timeout
         test(**cfg, release_timeout=-0.1)


### PR DESCRIPTION
What do you think about this? particularly the input_cutoff parameter is available from the gui, because it is relevant to set for rel-2-abs conversion. 