### PR TITLE
Prevent the daemon from choking with unsanitary device names

### DIFF
--- a/inputremapper/daemon.py
+++ b/inputremapper/daemon.py
@@ -43,7 +43,7 @@ from inputremapper.configs.preset import Preset
 from inputremapper.configs.global_config import global_config
 from inputremapper.configs.system_mapping import system_mapping
 from inputremapper.groups import groups
-from inputremapper.configs.paths import get_config_path, USER
+from inputremapper.configs.paths import get_config_path, sanitize_path_component, USER
 from inputremapper.injection.macros.macro import macro_variables
 from inputremapper.injection.global_uinputs import global_uinputs
 
@@ -437,7 +437,7 @@ class Daemon:
         preset_path = os.path.join(
             self.config_dir,
             "presets",
-            group.name,
+            sanitize_path_component(group.name),
             f"{preset}.json",
         )
 


### PR DESCRIPTION
A tiny fix that replaces path-unfriendly characters in device names such as my Logitech's "M585/590 Mouse". The slash in the name caused the daemon to fail when loading presets.

Not sure if this is the best way to fix this, I'm very new to input-remapper (only installed it just now). BTW it looks great and exactly what I was looking for, thanks for this!
