### PR TITLE
Not writing empty xmodmap files anymore

### DIFF
--- a/inputremapper/configs/system_mapping.py
+++ b/inputremapper/configs/system_mapping.py
@@ -49,7 +49,7 @@ class SystemMapping:
         self._xmodmap = None
         self._case_insensitive_mapping = None
 
-    def __getattribute__(self, wanted):
+    def __getattribute__(self, wanted: str):
         """To lazy load system_mapping info only when needed.
 
         For example, this helps to keep logs of input-remapper-control clear when it
@@ -67,7 +67,7 @@ class SystemMapping:
         return object.__getattribute__(self, wanted)
 
     def list_names(self, codes: Optional[Iterable[int]] = None) -> List[str]:
-        """Return a list of all possible names in the mapping, optionally filtered by codes.
+        """Get all possible names in the mapping, optionally filtered by codes.
 
         Parameters
         ----------
@@ -78,12 +78,53 @@ class SystemMapping:
 
         return [name for name, code in self._mapping.items() if code in codes]
 
-    def correct_case(self, symbol):
+    def correct_case(self, symbol: str):
         """Return the correct casing for a symbol."""
         if symbol in self._mapping:
             return symbol
         # only if not e.g. both "a" and "A" are in the mapping
         return self._case_insensitive_mapping.get(symbol.lower(), symbol)
+
+    def _use_xmodmap_symbols(self):
+        """Look up xmodmap -pke, write xmodmap.json, and get the symbols."""
+        try:
+            xmodmap = subprocess.check_output(
+                ["xmodmap", "-pke"],
+                stderr=subprocess.STDOUT,
+            ).decode()
+        except FileNotFoundError:
+            logger.info(
+                "Optional `xmodmap` command not found. This is not critical."
+            )
+            return
+        except subprocess.CalledProcessError as e:
+            logger.error('Call to `xmodmap -pke` failed with "%s"', e)
+            return
+
+        self._xmodmap = re.findall(r"(\d+) = (.+)\n", xmodmap + "\n")
+        xmodmap_dict = self._find_legit_mappings()
+        if len(xmodmap_dict) == 0:
+            logger.info("`xmodmap -pke` did not yield any symbol")
+            return
+
+        # Write this stuff into the input-remapper config directory, because
+        # the systemd service won't know the user sessions xmodmap.
+        path = get_config_path(XMODMAP_FILENAME)
+        touch(path)
+        with open(path, "w") as file:
+            logger.debug('Writing "%s"', path)
+            json.dump(xmodmap_dict, file, indent=4)
+
+        for name, code in xmodmap_dict.items():
+            self._set(name, code)
+
+    def _use_linux_evdev_symbols(self):
+        """Look up the evdev constant names and use them."""
+        for name, ecode in evdev.ecodes.ecodes.items():
+            if name.startswith("KEY") or name.startswith("BTN"):
+                self._set(name, ecode)
+
+        self._set(DISABLE_NAME, DISABLE_CODE)
 
     def populate(self):
         """Get a mapping of all available names to their keycodes."""
@@ -93,48 +134,16 @@ class SystemMapping:
         if not is_service():
             # xmodmap is only available from within the login session.
             # The service that runs via systemd can't use this.
-            xmodmap_dict = {}
-            try:
-                xmodmap = subprocess.check_output(
-                    ["xmodmap", "-pke"],
-                    stderr=subprocess.STDOUT,
-                ).decode()
-                xmodmap = xmodmap
-                self._xmodmap = re.findall(r"(\d+) = (.+)\n", xmodmap + "\n")
-                xmodmap_dict = self._find_legit_mappings()
-                if len(xmodmap_dict) == 0:
-                    logger.info("`xmodmap -pke` did not yield any symbol")
-            except FileNotFoundError:
-                logger.info(
-                    "Optional `xmodmap` command not found. This is not critical."
-                )
-            except subprocess.CalledProcessError as e:
-                logger.error('Call to `xmodmap -pke` failed with "%s"', e)
+            self._use_xmodmap_symbols()
 
-            # Clients usually take care of that, don't let the service do funny things.
-            # Write this stuff into the input-remapper config directory, because
-            # the systemd service won't know the user sessions xmodmap.
-            path = get_config_path(XMODMAP_FILENAME)
-            touch(path)
-            with open(path, "w") as file:
-                logger.debug('Writing "%s"', path)
-                json.dump(xmodmap_dict, file, indent=4)
+        self._use_linux_evdev_symbols()
 
-            for name, code in xmodmap_dict.items():
-                self._set(name, code)
-
-        for name, ecode in evdev.ecodes.ecodes.items():
-            if name.startswith("KEY") or name.startswith("BTN"):
-                self._set(name, ecode)
-
-        self._set(DISABLE_NAME, DISABLE_CODE)
-
-    def update(self, mapping):
+    def update(self, mapping: dict):
         """Update this with new keys.
 
         Parameters
         ----------
-        mapping : dict
+        mapping
             maps from name to code. Make sure your keys are lowercase.
         """
         len_before = len(self._mapping)
@@ -145,12 +154,12 @@ class SystemMapping:
             "Updated keycodes with %d new ones", len(self._mapping) - len_before
         )
 
-    def _set(self, name, code):
+    def _set(self, name: str, code: int):
         """Map name to code."""
         self._mapping[str(name)] = code
         self._case_insensitive_mapping[str(name).lower()] = name
 
-    def get(self, name) -> int:
+    def get(self, name: str) -> int:
         """Return the code mapped to the key."""
         # the correct casing should be shown when asking the system_mapping
         # for stuff. indexing case insensitive to support old presets.
@@ -166,7 +175,7 @@ class SystemMapping:
         for key in keys:
             del self._mapping[key]
 
-    def get_name(self, code):
+    def get_name(self, code: int):
         """Get the first matching name for the code."""
         for entry in self._xmodmap:
             if int(entry[0]) - XKB_KEYCODE_OFFSET == code:
@@ -174,7 +183,7 @@ class SystemMapping:
 
         return None
 
-    def _find_legit_mappings(self):
+    def _find_legit_mappings(self) -> dict:
         """From the parsed xmodmap list find usable symbols and their codes."""
         xmodmap_dict = {}
         for keycode, names in self._xmodmap:

--- a/inputremapper/configs/system_mapping.py
+++ b/inputremapper/configs/system_mapping.py
@@ -93,9 +93,7 @@ class SystemMapping:
                 stderr=subprocess.STDOUT,
             ).decode()
         except FileNotFoundError:
-            logger.info(
-                "Optional `xmodmap` command not found. This is not critical."
-            )
+            logger.info("Optional `xmodmap` command not found. This is not critical.")
             return
         except subprocess.CalledProcessError as e:
             logger.error('Call to `xmodmap -pke` failed with "%s"', e)


### PR DESCRIPTION
Noticed that xmodmap.json related logs were written even though xmodmap was not installed:

```
Optional `xmodmap` command not found. This is not critical.
Writing ".../xmodmap.json"
```

```
Using keycodes from ".../xmodmap.json"
```

This log was confusing