### PR TITLE
Single-Threaded Service

### DIFF
--- a/bin/input-remapper-control
+++ b/bin/input-remapper-control
@@ -131,11 +131,11 @@ def communicate(options, daemon):
             logger.info('Autoloading all')
             # timeout is not documented, for more info see
             # https://github.com/LEW21/pydbus/blob/master/pydbus/proxy_method.py
-            daemon.autoload(timeout=10)
+            daemon.autoload()
         else:
             group = require_group()
             logger.info('Asking daemon to autoload for %s', options.device)
-            daemon.autoload_single(group.key, timeout=2)
+            daemon.autoload_single(group.key)
 
     if options.command == START:
         group = require_group()

--- a/bin/input-remapper-service
+++ b/bin/input-remapper-service
@@ -50,5 +50,4 @@ if __name__ == '__main__':
         log_info('input-remapper-service')
 
     daemon = Daemon()
-    daemon.publish()
     daemon.run()

--- a/inputremapper/daemon.py
+++ b/inputremapper/daemon.py
@@ -363,7 +363,7 @@ class Daemon:
         self.config_dir = config_dir
         global_config.load_config(config_path)
 
-    def _autoload(self, group_key: str):
+    async def _autoload(self, group_key: str):
         """Check if autoloading is a good idea, and if so do it.
 
         Parameters
@@ -371,7 +371,7 @@ class Daemon:
         group_key
             unique identifier used by the groups object
         """
-        self.refresh(group_key)
+        await self.refresh(group_key)
 
         group = groups.find(key=group_key)
         if group is None:
@@ -400,7 +400,7 @@ class Daemon:
             )
             return
 
-        self.start_injecting(group.key, preset)
+        await self.start_injecting(group.key, preset)
         self.autoload_history.remember(group.key, preset)
 
     @ravel.method(
@@ -410,7 +410,7 @@ class Daemon:
         arg_keys=["group_key"],
     )
     @remove_timeout
-    def autoload_single(self, group_key: str):
+    async def autoload_single(self, group_key: str):
         """Inject the configured autoload preset for the device.
 
         If the preset is already being injected, it won't autoload it again.
@@ -434,11 +434,11 @@ class Daemon:
             )
             return
 
-        self._autoload(group_key)
+        await self._autoload(group_key)
 
     @ravel.method(name="autoload", in_signature="", out_signature="")
-    @remove_timeout
-    def autoload(self):
+    # @remove_timeout
+    async def autoload(self):
         """Load all autoloaded presets for the current config_dir.
 
         If the preset is already being injected, it won't autoload it again.
@@ -459,7 +459,7 @@ class Daemon:
             return
 
         for group_key, _ in autoload_presets:
-            self._autoload(group_key)
+            await self._autoload(group_key)
 
     @ravel.method(
         in_signature="ss",

--- a/inputremapper/groups.py
+++ b/inputremapper/groups.py
@@ -459,6 +459,7 @@ class _Groups:
         result is cached. Use refresh_groups if you need up to date
         devices.
         """
+        # todo: make sure this is non blocking or can be awaited
         pipe = multiprocessing.Pipe()
         _FindGroups(pipe[1]).start()
         # block until groups are available

--- a/inputremapper/injection/injector.py
+++ b/inputremapper/injection/injector.py
@@ -346,11 +346,6 @@ class Injector:
                 # give the event pipeline some time to reset devices
                 # before shutting the loop down
                 await asyncio.sleep(0.1)
-
-                # stop the event loop and cause the process to reach its end
-                # cleanly. Using .terminate prevents coverage from working.
-                loop.stop()
-                self._msg_pipe[0].send(InjectorState.STOPPED)
                 return
 
     def _create_forwarding_device(self, source: evdev.InputDevice) -> evdev.UInput:

--- a/inputremapper/injection/injector.py
+++ b/inputremapper/injection/injector.py
@@ -101,7 +101,7 @@ class InjectorStateMessage:
         return self.state in [InjectorState.STOPPED, InjectorState.NO_GRAB]
 
 
-class Injector(multiprocessing.Process):
+class Injector:
     """Initializes, starts and stops injections.
 
     Is a process to make it non-blocking for the rest of the code and to
@@ -382,7 +382,7 @@ class Injector(multiprocessing.Process):
             raise e
         return forward_to
 
-    def run(self) -> None:
+    async def run(self) -> None:
         """The injection worker that keeps injecting until terminated.
 
         Stuff is non-blocking by using asyncio in order to do multiple things
@@ -397,10 +397,10 @@ class Injector(multiprocessing.Process):
         # that sleeps on iterations (joystick_to_mouse) in one process causes
         # another injection process to screw up reading from the grabbed
         # device.
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-
-        self._devices = self.group.get_devices()
+        # loop = asyncio.new_event_loop()
+        # asyncio.set_event_loop(loop)
+	
+	self._devices = self.group.get_devices()
 
         # InputConfigs may not contain the origin_hash information, this will try to make a
         # good guess if the origin_hash information is missing or invalid.
@@ -445,7 +445,7 @@ class Injector(multiprocessing.Process):
         self._msg_pipe[0].send(InjectorState.RUNNING)
 
         try:
-            loop.run_until_complete(asyncio.gather(*coroutines))
+            await asyncio.gather(*coroutines)
         except RuntimeError as error:
             # the loop might have been stopped via a `CLOSE` message,
             # which causes the error message below. This is expected behavior

--- a/tests/lib/pipes.py
+++ b/tests/lib/pipes.py
@@ -77,6 +77,7 @@ def push_event(fixture: Fixture, event, force: bool = False):
     ):
         raise AssertionError(f"Fixture {fixture.path} cannot send {event}")
     logger.info("Simulating %s for %s", event, fixture.path)
+    logger.info(f"Pipe: {pending_events[fixture]}")
     pending_events[fixture][0].send(event)
 
 

--- a/tests/lib/stuff.py
+++ b/tests/lib/stuff.py
@@ -32,7 +32,7 @@ def convert_to_internal_events(events):
 
 def spy(obj, name):
     """Convenient wrapper for patch.object(..., ..., wraps=...)."""
-    return patch.object(obj, name, wraps=obj.__getattribute__(name))
+    return patch.object(obj, name, wraps=getattr(obj, name))
 
 
 environ_copy = copy.deepcopy(os.environ)

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -53,7 +53,7 @@ os_system = os.system
 dbus_get = type(SystemBus()).get
 
 
-class TestDaemon(unittest.TestCase):
+class TestDaemon(unittest.IsolatedAsyncioTestCase):
     new_fixture_path = "/dev/input/event9876"
 
     def setUp(self):
@@ -432,7 +432,7 @@ class TestDaemon(unittest.TestCase):
         preset.save()
 
         # no autoloading is configured yet
-        self.daemon._autoload(group_key)
+        await self.daemon._autoload(group_key)
         self.assertNotIn(group_key, daemon.autoload_history._autoload_history)
         self.assertTrue(daemon.autoload_history.may_autoload(group_key, preset_name))
 
@@ -448,8 +448,8 @@ class TestDaemon(unittest.TestCase):
         injector = daemon.injectors[group_key]
         self.assertEqual(len_before + 1, len_after)
 
-        # calling duplicate get_autoload does nothing
-        self.daemon._autoload(group_key)
+        # calling duplicate autoload does nothing
+        await self.daemon._autoload(group_key)
         self.assertEqual(
             daemon.autoload_history._autoload_history[group_key][1], preset_name
         )
@@ -457,18 +457,18 @@ class TestDaemon(unittest.TestCase):
         self.assertFalse(daemon.autoload_history.may_autoload(group_key, preset_name))
 
         # explicit start_injecting clears the autoload history
-        self.daemon.start_injecting(group_key, preset_name)
+        await self.daemon.start_injecting(group_key, preset_name)
         self.assertTrue(daemon.autoload_history.may_autoload(group_key, preset_name))
 
         # calling autoload for (yet) unknown devices does nothing
         len_before = len(self.daemon.autoload_history._autoload_history)
-        self.daemon._autoload("unknown-key-1234")
+        await self.daemon._autoload("unknown-key-1234")
         len_after = len(self.daemon.autoload_history._autoload_history)
         self.assertEqual(len_before, len_after)
 
         # autoloading input-remapper devices does nothing
         len_before = len(self.daemon.autoload_history._autoload_history)
-        self.daemon.autoload_single("Bar Device")
+        await self.daemon.autoload_single("Bar Device")
         len_after = len(self.daemon.autoload_history._autoload_history)
         self.assertEqual(len_before, len_after)
 


### PR DESCRIPTION
This runs the Service in a single process. 
It should reduce overhead (only one python interpreter running) and it allows for better Profiling. In addition it allows us to simplify the injector, shared-dict and test-fixtures because we can remove all the communication stuff.

There is one issue with this: the use of a different dbus library [dbus-next](https://github.com/altdesktop/python-dbus-next). This is needed because the current library pydbus needs a GLib.MainLoop, which is incompatible with asyncio. There is a [merge-request](https://gitlab.gnome.org/GNOME/pygobject/-/merge_requests/189) to add a asyncio compatible GLib.MainLoop, but who knows when this is ready.

Unfortunately dbus-next is not part of the Ubuntu repos. 
An alternative could be [dbussy](https://github.com/ldo/dbussy) but that deliberately introduces inconsistency with method return types ([see this issue](https://github.com/ldo/dbussy/issues/30)). 
There is also [jeepney](https://gitlab.com/takluyver/jeepney), but that is missing a high level interface, so it will require extra work.
Both of these alternatives are part of the ubuntu repos. But I still think that dbus-next offers the best interface with only one [issue](https://github.com/altdesktop/python-dbus-next/issues/119) for which I found a workaround.

So the question is:
 - do we want this?
   - I think yes, it will make the code simpler to reason about.
 - Is a single process fast enough to handle multiple devices with high polling rates?
   - [ ] this needs testing
 - do we want to, and can we package InputRemapper with dbus-next?