### PR TITLE
Add AppStream metadata

### DIFF
--- a/data/io.github.sezanzeb.input_remapper.metainfo.xml
+++ b/data/io.github.sezanzeb.input_remapper.metainfo.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright [year] [name] -->
+<component type="desktop-application">
+  <id>io.github.sezanzeb.input_remapper</id>
+  
+  <name>Input Remapper</name>
+  <summary>An easy to use tool to change the mapping of your input device buttons</summary>
+  
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  
+  <supports>
+    <control>pointing</control>
+    <control>keyboard</control>
+    <control>gamepad</control>
+  </supports>
+  
+  <description>
+    <p>
+      An easy to use tool to change the mapping of your input device buttons. Supports mice, keyboards, gamepads, X11, Wayland, combined buttons and programmable macros. Allows mapping non-keyboard events (click, joystick, wheel) to keys of keyboard devices.
+    </p>
+  </description>
+  
+  <launchable type="desktop-id">input-remapper.desktop</launchable>
+  
+  <screenshots>
+    <screenshot type="default">
+      <caption>Defining a new mapping</caption>
+      <image>https://raw.githubusercontent.com/sezanzeb/input-remapper/main/readme/screenshot.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/sezanzeb/input-remapper/main/readme/screenshot_2.png</image>
+    </screenshot>
+  </screenshots>
+  
+  <url type="homepage">https://github.com/sezanzeb/input-remapper</url>
+  
+  <content_rating type="oars-1.1" />
+  
+  <releases>
+    <release version="1.5.0" date="2022-06-22" />
+  </releases>
+  
+</component>

--- a/setup.py
+++ b/setup.py
@@ -115,6 +115,7 @@ setup(
         *lang_data,
         ("/usr/share/input-remapper/", glob.glob("data/*")),
         ("/usr/share/applications/", ["data/input-remapper.desktop"]),
+        ("/usr/share/metainfo/", ["data/io.github.sezanzeb.input_remapper.metainfo.xml"]),
         ("/usr/share/polkit-1/actions/", ["data/input-remapper.policy"]),
         ("/usr/lib/systemd/system", ["data/input-remapper.service"]),
         ("/etc/dbus-1/system.d/", ["data/inputremapper.Control.conf"]),


### PR DESCRIPTION
I've created a basic AppStream MetaInfo file and I've added a directive in setup.py for it to be placed in the /usr/share/metainfo/ directory.

I tried to follow the [documentation](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-id-generic) regarding the <id> tag and I replaced with an underscore the hyphen in the name, as their use is "discouraged".

As I wrote in https://github.com/sezanzeb/input-remapper/issues/537#issuecomment-1356863846, new screenshots will have to be created at a 16:9 ratio and the current minimum recommended height is 351 px (without padding).

I've left a placeholder copyright comment (the second line).