### PR TITLE
Improved error formatting in status bar

### DIFF
--- a/bin/input-remapper-gtk
+++ b/bin/input-remapper-gtk
@@ -27,10 +27,9 @@ import atexit
 from argparse import ArgumentParser
 
 import gi
-
-gi.require_version("Gtk", "3.0")
-gi.require_version("GLib", "2.0")
-gi.require_version("GtkSource", "4")
+gi.require_version('Gtk', '3.0')
+gi.require_version('GLib', '2.0')
+gi.require_version('GtkSource', '4')
 from gi.repository import Gtk
 
 # https://github.com/Nuitka/Nuitka/issues/607#issuecomment-650217096
@@ -54,21 +53,18 @@ def start_processes() -> DaemonProxy:
     return Daemon.connect()
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     parser = ArgumentParser()
     parser.add_argument(
-        "-d",
-        "--debug",
-        action="store_true",
-        dest="debug",
-        help=_("Displays additional debug information"),
-        default=False,
+        '-d', '--debug', action='store_true', dest='debug',
+        help=_('Displays additional debug information'),
+        default=False
     )
 
     options = parser.parse_args(sys.argv[1:])
     update_verbosity(options.debug)
-    log_info("input-remapper-gtk")
-    logger.debug("Using locale directory: {}".format(LOCALE_DIR))
+    log_info('input-remapper-gtk')
+    logger.debug('Using locale directory: {}'.format(LOCALE_DIR))
 
     # import input-remapper stuff after setting the log verbosity
     from inputremapper.gui.messages.message_broker import MessageBroker, MessageType
@@ -93,12 +89,7 @@ if __name__ == "__main__":
     daemon = start_processes()
 
     data_manager = DataManager(
-        message_broker,
-        GlobalConfig(),
-        reader_client,
-        daemon,
-        GlobalUInputs(),
-        system_mapping,
+        message_broker, GlobalConfig(), reader_client, daemon, GlobalUInputs(), system_mapping
     )
     controller = Controller(message_broker, data_manager)
     user_interface = UserInterface(message_broker, controller)

--- a/bin/input-remapper-gtk
+++ b/bin/input-remapper-gtk
@@ -27,9 +27,10 @@ import atexit
 from argparse import ArgumentParser
 
 import gi
-gi.require_version('Gtk', '3.0')
-gi.require_version('GLib', '2.0')
-gi.require_version('GtkSource', '4')
+
+gi.require_version("Gtk", "3.0")
+gi.require_version("GLib", "2.0")
+gi.require_version("GtkSource", "4")
 from gi.repository import Gtk
 
 # https://github.com/Nuitka/Nuitka/issues/607#issuecomment-650217096
@@ -53,18 +54,21 @@ def start_processes() -> DaemonProxy:
     return Daemon.connect()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     parser = ArgumentParser()
     parser.add_argument(
-        '-d', '--debug', action='store_true', dest='debug',
-        help=_('Displays additional debug information'),
-        default=False
+        "-d",
+        "--debug",
+        action="store_true",
+        dest="debug",
+        help=_("Displays additional debug information"),
+        default=False,
     )
 
     options = parser.parse_args(sys.argv[1:])
     update_verbosity(options.debug)
-    log_info('input-remapper-gtk')
-    logger.debug('Using locale directory: {}'.format(LOCALE_DIR))
+    log_info("input-remapper-gtk")
+    logger.debug("Using locale directory: {}".format(LOCALE_DIR))
 
     # import input-remapper stuff after setting the log verbosity
     from inputremapper.gui.messages.message_broker import MessageBroker, MessageType
@@ -89,7 +93,12 @@ if __name__ == '__main__':
     daemon = start_processes()
 
     data_manager = DataManager(
-        message_broker, GlobalConfig(), reader_client, daemon, GlobalUInputs(), system_mapping
+        message_broker,
+        GlobalConfig(),
+        reader_client,
+        daemon,
+        GlobalUInputs(),
+        system_mapping,
     )
     controller = Controller(message_broker, data_manager)
     user_interface = UserInterface(message_broker, controller)

--- a/data/input-remapper.glade
+++ b/data/input-remapper.glade
@@ -851,13 +851,13 @@ Shortcut: ctrl + del</property>
                                   <object class="GtkBox">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
+                                    <property name="tooltip-text" translatable="yes">Available output axes are affected by the Target setting.</property>
                                     <property name="spacing">12</property>
                                     <child>
                                       <object class="GtkLabel">
                                         <property name="width-request">100</property>
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="tooltip-text" translatable="yes">Available output axes are affected by the Target setting.</property>
                                         <property name="opacity">0.5</property>
                                         <property name="label" translatable="yes">Output axis</property>
                                         <property name="xalign">1</property>

--- a/data/input-remapper.glade
+++ b/data/input-remapper.glade
@@ -419,6 +419,7 @@ Shortcut: ctrl + del</property>
                       <object class="GtkSwitch" id="preset_autoload_switch">
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
+                        <property name="tooltip-text" translatable="yes">Activate this to load the preset next time the device connects, or when the user logs in</property>
                         <property name="halign">start</property>
                         <property name="valign">center</property>
                       </object>

--- a/inputremapper/configs/mapping.py
+++ b/inputremapper/configs/mapping.py
@@ -118,8 +118,8 @@ def pydantify(error: type):
     """
     # See https://github.com/pydantic/pydantic/discussions/5112
     lower_classname = error.__name__.lower()
-    if lower_classname.endswith('error'):
-        return lower_classname[:-len('error')]
+    if lower_classname.endswith("error"):
+        return lower_classname[: -len("error")]
     return lower_classname
 
 
@@ -525,9 +525,7 @@ class Mapping(UIMapping):
         output_symbol = values.get("output_symbol")
 
         if not use_as_analog and not output_symbol and output_type != EV_KEY:
-            raise MissingMacroOrKeyError(
-                f'missing macro or key'
-            )
+            raise MissingMacroOrKeyError(f"missing macro or key")
 
         if (
             use_as_analog

--- a/inputremapper/configs/mapping.py
+++ b/inputremapper/configs/mapping.py
@@ -368,14 +368,10 @@ class Mapping(UIMapping):
             return values
 
         if is_this_a_macro(symbol):
-            try:
-                mapping_mock = namedtuple("Mapping", values.keys())(**values)
-                # raises MacroParsingError
-                parse(symbol, mapping=mapping_mock, verbose=False)
-                return values
-            except MacroParsingError as exception:
-                # pydantic only catches ValueError, TypeError, and AssertionError
-                raise ValueError(exception) from exception
+            mapping_mock = namedtuple("Mapping", values.keys())(**values)
+            # raises MacroParsingError
+            parse(symbol, mapping=mapping_mock, verbose=False)
+            return values
 
         code = system_mapping.get(symbol)
         if code is None:

--- a/inputremapper/configs/mapping.py
+++ b/inputremapper/configs/mapping.py
@@ -51,7 +51,7 @@ from inputremapper.configs.system_mapping import system_mapping, DISABLE_NAME
 from inputremapper.exceptions import MacroParsingError
 from inputremapper.gui.gettext import _
 from inputremapper.gui.messages.message_types import MessageType
-from inputremapper.injection.global_uinputs import global_uinputs, DEFAULT_UINPUTS
+from inputremapper.injection.global_uinputs import DEFAULT_UINPUTS
 from inputremapper.injection.macros.parse import is_this_a_macro, parse
 from inputremapper.utils import get_evdev_constant_name
 
@@ -343,10 +343,18 @@ class Mapping(UIMapping):
         """Parse a macro to check for syntax errors."""
         symbol = values.get("output_symbol")
 
-        if not symbol:
+        if symbol == '':
+            values["output_symbol"] = None
+            return values
+
+        if symbol is None:
             return values
 
         symbol = symbol.strip()
+        values["output_symbol"] = symbol
+
+        if symbol == DISABLE_NAME:
+            return values
 
         if is_this_a_macro(symbol):
             try:
@@ -430,10 +438,13 @@ class Mapping(UIMapping):
         type_ = values.get("output_type")
         code = values.get("output_code")
         if symbol is None:
-            return values  # type and code can be anything
+            # If symbol is "", then validate_symbol changes it to None
+            # type and code can be anything
+            return values
 
         if type_ is None and code is None:
-            return values  # we have a symbol: no type and code is fine
+            # we have a symbol: no type and code is fine
+            return values
 
         if is_this_a_macro(symbol):  # disallow output type and code for macros
             if type_ is not None or code is not None:

--- a/inputremapper/configs/mapping.py
+++ b/inputremapper/configs/mapping.py
@@ -365,7 +365,7 @@ class Mapping(UIMapping):
 
         target = values.get("target_uinput")
         capabilities = DEFAULT_UINPUTS.get(target, {}).get(EV_KEY)
-        if code not in capabilities:
+        if capabilities is not None and code not in capabilities:
             fitting_targets = [
                 uinput
                 for uinput in DEFAULT_UINPUTS

--- a/inputremapper/configs/mapping.py
+++ b/inputremapper/configs/mapping.py
@@ -110,19 +110,6 @@ class ImmutableCfg(Cfg):
     allow_mutation = False
 
 
-def pydantify(error: type):
-    """Generate a string as it would appear IN pydantic error types.
-
-    This does not include the base class name, which is transformed to snake case in
-    pydantic. Example pydantic error type: "value_error.foobar" for FooBarError.
-    """
-    # See https://github.com/pydantic/pydantic/discussions/5112
-    lower_classname = error.__name__.lower()
-    if lower_classname.endswith("error"):
-        return lower_classname[: -len("error")]
-    return lower_classname
-
-
 class OutputSymbolVariantError(ValueError):
     pass
 

--- a/inputremapper/configs/validation_errors.py
+++ b/inputremapper/configs/validation_errors.py
@@ -30,7 +30,6 @@ from typing import Optional
 from evdev.ecodes import EV_KEY
 
 from inputremapper.configs.system_mapping import system_mapping
-from inputremapper.exceptions import Error
 from inputremapper.injection.global_uinputs import find_fitting_default_uinputs
 
 

--- a/inputremapper/configs/validation_errors.py
+++ b/inputremapper/configs/validation_errors.py
@@ -110,8 +110,7 @@ class MissingOutputAxisError(ValueError):
         )
 
 
-# TODO ValueError
-class MacroParsingError(Error):
+class MacroParsingError(ValueError):
     """Macro syntax errors."""
 
     def __init__(self, symbol: Optional[str] = None, msg="Error while parsing a macro"):

--- a/inputremapper/configs/validation_errors.py
+++ b/inputremapper/configs/validation_errors.py
@@ -23,6 +23,8 @@
 # be intelligent to avoid redundant code, and they need imports, which would cause
 # circular imports.
 
+# pydantic only catches ValueError, TypeError, and AssertionError
+
 from __future__ import annotations
 
 from typing import Optional

--- a/inputremapper/configs/validation_errors.py
+++ b/inputremapper/configs/validation_errors.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+# input-remapper - GUI for device specific keyboard mappings
+# Copyright (C) 2022 sezanzeb <proxima@sezanzeb.de>
+#
+# This file is part of input-remapper.
+#
+# input-remapper is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# input-remapper is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with input-remapper.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Exceptions that are thrown when configurations are incorrect."""
+
+# can't merge this with exceptions.py, because I want error constructors here to
+# be intelligent to avoid redundant code, and they need imports, which would cause
+# circular imports.
+
+from __future__ import annotations
+
+from typing import Optional
+
+from evdev.ecodes import EV_KEY
+
+from inputremapper.configs.system_mapping import system_mapping
+from inputremapper.exceptions import Error
+from inputremapper.injection.global_uinputs import find_fitting_default_uinputs
+
+
+class OutputSymbolVariantError(ValueError):
+    def __init__(self):
+        super().__init__(
+            "Missing Argument: Mapping must either contain "
+            "`output_symbol` or `output_type` and `output_code`"
+        )
+
+
+class TriggerPointInRangeError(ValueError):
+    def __init__(self, input_config):
+        super().__init__(
+            f"{input_config = } maps an absolute axis to a button, but the "
+            "trigger point (event.analog_threshold) is not between -100[%] "
+            "and 100[%]"
+        )
+
+
+class OnlyOneAnalogInputError(ValueError):
+    def __init__(self, analog_events):
+        super().__init__(
+            f"Cannot map a combination of multiple analog inputs: {analog_events}"
+            "add trigger points (event.value != 0) to map as a button"
+        )
+
+
+class SymbolNotAvailableInTargetError(ValueError):
+    def __init__(self, symbol, target):
+        code = system_mapping.get(symbol)
+
+        fitting_targets = find_fitting_default_uinputs(EV_KEY, code)
+        fitting_targets_string = '", "'.join(fitting_targets)
+
+        super().__init__(
+            f'The output_symbol "{symbol}" is not available for the "{target}" '
+            + f'target. Try "{fitting_targets_string}".'
+        )
+
+
+class OutputSymbolUnknownError(ValueError):
+    def __init__(self, symbol: str):
+        super().__init__(
+            f'The output_symbol "{symbol}" is not a macro and not a valid '
+            + "keycode-name"
+        )
+
+
+class MacroButTypeOrCodeSetError(ValueError):
+    def __init__(self):
+        super().__init__(
+            "output_symbol is a macro: output_type " "and output_code must be None"
+        )
+
+
+class SymbolAndCodeMismatchError(ValueError):
+    def __init__(self, symbol, code):
+        super().__init__(
+            "output_symbol and output_code mismatch: "
+            f"output macro is {symbol} -> {system_mapping.get(symbol)} "
+            f"but output_code is {code} -> {system_mapping.get_name(code)} "
+        )
+
+
+class MissingMacroOrKeyError(ValueError):
+    def __init__(self):
+        super().__init__("missing macro or key")
+
+
+class MissingOutputAxisError(ValueError):
+    def __init__(self, analog_input_config, output_type):
+        super().__init__(
+            "Missing output axis: "
+            f'"{analog_input_config}" is used as analog input, '
+            f"but the {output_type = } is not an axis "
+        )
+
+
+# TODO ValueError
+class MacroParsingError(Error):
+    """Macro syntax errors."""
+
+    def __init__(self, symbol: Optional[str] = None, msg="Error while parsing a macro"):
+        self.symbol = symbol
+        super().__init__(msg)

--- a/inputremapper/configs/validation_errors.py
+++ b/inputremapper/configs/validation_errors.py
@@ -117,3 +117,16 @@ class MacroParsingError(ValueError):
     def __init__(self, symbol: Optional[str] = None, msg="Error while parsing a macro"):
         self.symbol = symbol
         super().__init__(msg)
+
+
+def pydantify(error: type):
+    """Generate a string as it would appear IN pydantic error types.
+
+    This does not include the base class name, which is transformed to snake case in
+    pydantic. Example pydantic error type: "value_error.foobar" for FooBarError.
+    """
+    # See https://github.com/pydantic/pydantic/discussions/5112
+    lower_classname = error.__name__.lower()
+    if lower_classname.endswith("error"):
+        return lower_classname[: -len("error")]
+    return lower_classname

--- a/inputremapper/exceptions.py
+++ b/inputremapper/exceptions.py
@@ -20,8 +20,6 @@
 
 """Exceptions specific to inputremapper."""
 
-from typing import Optional
-
 
 class Error(Exception):
     """Base class for exceptions in inputremapper.
@@ -42,14 +40,6 @@ class EventNotHandled(Error):
 
     def __init__(self, event):
         super().__init__(f"Event {event} can not be handled by the configured target")
-
-
-class MacroParsingError(Error):
-    """Macro syntax errors."""
-
-    def __init__(self, symbol: Optional[str] = None, msg="Error while parsing a macro"):
-        self.symbol = symbol
-        super().__init__(msg)
 
 
 class MappingParsingError(Error):

--- a/inputremapper/gui/components/main.py
+++ b/inputremapper/gui/components/main.py
@@ -23,8 +23,6 @@
 
 from __future__ import annotations
 
-import time
-
 import gi
 from gi.repository import Gtk, Pango
 
@@ -34,7 +32,7 @@ from inputremapper.gui.messages.message_broker import (
     MessageType,
 )
 from inputremapper.gui.messages.message_data import StatusData, DoStackSwitch
-from inputremapper.gui.utils import CTX_ERROR, CTX_MAPPING, CTX_WARNING, gtk_iteration
+from inputremapper.gui.utils import CTX_ERROR, CTX_MAPPING, CTX_WARNING
 
 
 class Stack:

--- a/inputremapper/gui/components/main.py
+++ b/inputremapper/gui/components/main.py
@@ -77,9 +77,9 @@ class StatusBar:
         self._error_icon = error_icon
         self._warning_icon = warning_icon
 
-        self._gui.get_message_area().get_children()[0].set_ellipsize(
-            Pango.EllipsizeMode.END
-        )
+        label = self._gui.get_message_area().get_children()[0]
+        label.set_ellipsize(Pango.EllipsizeMode.END)
+        label.set_selectable(True)
 
         self._message_broker.subscribe(MessageType.status_msg, self._on_status_update)
 

--- a/inputremapper/gui/components/main.py
+++ b/inputremapper/gui/components/main.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import time
 
 import gi
-from gi.repository import Gtk
+from gi.repository import Gtk, Pango
 
 from inputremapper.gui.controller import Controller
 from inputremapper.gui.messages.message_broker import (
@@ -79,6 +79,10 @@ class StatusBar:
         self._error_icon = error_icon
         self._warning_icon = warning_icon
 
+        self._gui.get_message_area().get_children()[0].set_ellipsize(
+            Pango.EllipsizeMode.END
+        )
+
         self._message_broker.subscribe(MessageType.status_msg, self._on_status_update)
 
         # keep track if there is an error or warning in the stack of statusbar
@@ -128,10 +132,6 @@ class StatusBar:
         if context_id == CTX_WARNING:
             self._warning_icon.show()
             self._warning = True
-
-        max_length = 135
-        if len(message) > max_length:
-            message = message[: max_length - 3] + "..."
 
         status_bar.push(context_id, message)
         status_bar.set_tooltip_text(tooltip)

--- a/inputremapper/gui/controller.py
+++ b/inputremapper/gui/controller.py
@@ -688,9 +688,9 @@ class Controller:
                 self.show_status,
                 CTX_ERROR,
                 "The device was not grabbed",
-                "Either another application is already grabbing it or "
+                "Either another application is already grabbing it, "
                 "your preset doesn't contain anything that is sent by the "
-                "device.",
+                "device or your preset contains errors",
             ),
             InjectorState.UPGRADE_EVDEV: partial(
                 self.show_status,

--- a/inputremapper/gui/controller.py
+++ b/inputremapper/gui/controller.py
@@ -263,8 +263,6 @@ class Controller:
         if validation_error is None:
             return []
 
-        logger.error(str(validation_error).replace('\n', ' / '))
-
         formatted_errors = []
 
         for error in validation_error.errors():

--- a/inputremapper/gui/controller.py
+++ b/inputremapper/gui/controller.py
@@ -46,7 +46,6 @@ from inputremapper.configs.mapping import (
     MissingOutputAxisError,
     MissingMacroOrKeyError,
     OutputSymbolVariantError,
-    pydantify,
 )
 from inputremapper.configs.paths import sanitize_path_component
 from inputremapper.configs.input_config import InputCombination, InputConfig
@@ -77,6 +76,19 @@ if TYPE_CHECKING:
 
 
 MAPPING_DEFAULTS = {"target_uinput": "keyboard"}
+
+
+def pydantify(error: type):
+    """Generate a string as it would appear IN pydantic error types.
+
+    This does not include the base class name, which is transformed to snake case in
+    pydantic. Example pydantic error type: "value_error.foobar" for FooBarError.
+    """
+    # See https://github.com/pydantic/pydantic/discussions/5112
+    lower_classname = error.__name__.lower()
+    if lower_classname.endswith("error"):
+        return lower_classname[: -len("error")]
+    return lower_classname
 
 
 class Controller:
@@ -251,7 +263,7 @@ class Controller:
         if validation_error is None:
             return []
 
-        logger.error(str(validation_error))
+        logger.error(str(validation_error).replace('\n', ' / '))
 
         formatted_errors = []
 

--- a/inputremapper/gui/controller.py
+++ b/inputremapper/gui/controller.py
@@ -38,9 +38,16 @@ from evdev.ecodes import EV_KEY, EV_REL, EV_ABS
 
 from gi.repository import Gtk
 
-from inputremapper.configs.mapping import MappingData, UIMapping, \
-    MacroButTypeOrCodeSetError, SymbolAndCodeMismatchError, MissingOutputAxisError, \
-    MissingMacroOrKeyError, OutputSymbolVariantError, pydantify
+from inputremapper.configs.mapping import (
+    MappingData,
+    UIMapping,
+    MacroButTypeOrCodeSetError,
+    SymbolAndCodeMismatchError,
+    MissingOutputAxisError,
+    MissingMacroOrKeyError,
+    OutputSymbolVariantError,
+    pydantify,
+)
 from inputremapper.configs.paths import sanitize_path_component
 from inputremapper.configs.input_config import InputCombination, InputConfig
 from inputremapper.exceptions import DataManagementError
@@ -185,8 +192,8 @@ class Controller:
         # There is no more elegant way of comparing error_type with the base class.
         # https://github.com/pydantic/pydantic/discussions/5112
         if (
-            pydantify(MacroButTypeOrCodeSetError) in error_type or
-            pydantify(SymbolAndCodeMismatchError) in error_type
+            pydantify(MacroButTypeOrCodeSetError) in error_type
+            or pydantify(SymbolAndCodeMismatchError) in error_type
         ) and mapping.input_combination.defines_analog_input:
             return _(
                 "Remove the macro or key from the macro input field "
@@ -194,8 +201,8 @@ class Controller:
             )
 
         if (
-            pydantify(MacroButTypeOrCodeSetError) in error_type or
-            pydantify(SymbolAndCodeMismatchError) in error_type
+            pydantify(MacroButTypeOrCodeSetError) in error_type
+            or pydantify(SymbolAndCodeMismatchError) in error_type
         ) and not mapping.input_combination.defines_analog_input:
             return _(
                 "Remove the Analog Output Axis when specifying a macro or key output"
@@ -220,8 +227,8 @@ class Controller:
             return error_message
 
         if (
-            pydantify(MissingMacroOrKeyError) in error_type and
-            mapping.output_symbol is None
+            pydantify(MissingMacroOrKeyError) in error_type
+            and mapping.output_symbol is None
         ):
             error_message = _(
                 "The input specifies a key or macro input, but no macro or key is "

--- a/inputremapper/gui/controller.py
+++ b/inputremapper/gui/controller.py
@@ -49,6 +49,7 @@ from inputremapper.configs.mapping import (
 )
 from inputremapper.configs.paths import sanitize_path_component
 from inputremapper.configs.input_config import InputCombination, InputConfig
+from inputremapper.configs.validation_errors import pydantify
 from inputremapper.exceptions import DataManagementError
 from inputremapper.gui.data_manager import DataManager, DEFAULT_PRESET_NAME
 from inputremapper.gui.gettext import _
@@ -76,19 +77,6 @@ if TYPE_CHECKING:
 
 
 MAPPING_DEFAULTS = {"target_uinput": "keyboard"}
-
-
-def pydantify(error: type):
-    """Generate a string as it would appear IN pydantic error types.
-
-    This does not include the base class name, which is transformed to snake case in
-    pydantic. Example pydantic error type: "value_error.foobar" for FooBarError.
-    """
-    # See https://github.com/pydantic/pydantic/discussions/5112
-    lower_classname = error.__name__.lower()
-    if lower_classname.endswith("error"):
-        return lower_classname[: -len("error")]
-    return lower_classname
 
 
 class Controller:

--- a/inputremapper/injection/global_uinputs.py
+++ b/inputremapper/injection/global_uinputs.py
@@ -70,7 +70,7 @@ def find_fitting_default_uinputs(type_: int, code: int) -> List[str]:
     return [
         uinput
         for uinput in DEFAULT_UINPUTS
-        if code in DEFAULT_UINPUTS[uinput].get(type_)
+        if code in DEFAULT_UINPUTS[uinput].get(type_, [])
     ]
 
 

--- a/inputremapper/injection/global_uinputs.py
+++ b/inputremapper/injection/global_uinputs.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with input-remapper.  If not, see <https://www.gnu.org/licenses/>.
 
-from typing import Dict, Union, Tuple, Optional
+from typing import Dict, Union, Tuple, Optional, List
 
 import evdev
 
@@ -57,6 +57,21 @@ DEFAULT_UINPUTS["keyboard + mouse"] = {
         *DEFAULT_UINPUTS["mouse"][evdev.ecodes.EV_REL],
     ],
 }
+
+
+def can_default_uinput_emit(target: str, type_: int, code: int) -> bool:
+    """Check if the uinput with the target name is capable of the event."""
+    capabilities = DEFAULT_UINPUTS.get(target, {}).get(type_)
+    return capabilities is not None and code in capabilities
+
+
+def find_fitting_default_uinputs(type_: int, code: int) -> List[str]:
+    """Find the names of default uinputs that are able to emit this event."""
+    return [
+        uinput
+        for uinput in DEFAULT_UINPUTS
+        if code in DEFAULT_UINPUTS[uinput].get(type_)
+    ]
 
 
 class UInput(evdev.UInput):

--- a/inputremapper/injection/macros/macro.py
+++ b/inputremapper/injection/macros/macro.py
@@ -690,7 +690,7 @@ class Macro:
 
         self.tasks.append(task)
 
-    def _type_check_symbol(self, keyname: Union[str, Variable]) -> Union[str, int]:
+    def _type_check_symbol(self, keyname: Union[str, Variable]) -> Union[Variable, int]:
         """Same as _type_check, but checks if the key-name is valid."""
         if isinstance(keyname, Variable):
             # it is a variable and will be read at runtime

--- a/inputremapper/injection/macros/macro.py
+++ b/inputremapper/injection/macros/macro.py
@@ -690,7 +690,7 @@ class Macro:
 
         self.tasks.append(task)
 
-    def _type_check_symbol(self, keyname: Union[str, Variable]) -> int:
+    def _type_check_symbol(self, keyname: Union[str, Variable]) -> Union[str, int]:
         """Same as _type_check, but checks if the key-name is valid."""
         if isinstance(keyname, Variable):
             # it is a variable and will be read at runtime

--- a/inputremapper/injection/macros/macro.py
+++ b/inputremapper/injection/macros/macro.py
@@ -55,7 +55,11 @@ from evdev.ecodes import (
 )
 
 from inputremapper.configs.system_mapping import system_mapping
-from inputremapper.exceptions import MacroParsingError
+from inputremapper.configs.validation_errors import (
+    SymbolNotAvailableInTargetError,
+    MacroParsingError,
+)
+from inputremapper.injection.global_uinputs import can_default_uinput_emit
 from inputremapper.ipc.shared_dict import SharedDict
 from inputremapper.logger import logger
 
@@ -123,21 +127,6 @@ def _type_check(value: Any, allowed_types, display_name=None, position=None) -> 
     raise MacroParsingError(
         msg=f"Expected parameter to be one of {allowed_types}, but got {value}"
     )
-
-
-def _type_check_symbol(keyname: Union[str, Variable]) -> int:
-    """Same as _type_check, but checks if the key-name is valid."""
-    if isinstance(keyname, Variable):
-        # it is a variable and will be read at runtime
-        return keyname
-
-    symbol = str(keyname)
-    code = system_mapping.get(symbol)
-
-    if code is None:
-        raise MacroParsingError(msg=f'Unknown key "{symbol}"')
-
-    return code
 
 
 def _type_check_variablename(name: str):
@@ -215,6 +204,8 @@ class Macro:
         self.code = code
         self.context = context
         self.mapping = mapping
+
+        # TODO check if mapping is ever none by throwing an error
 
         # List of coroutines that will be called sequentially.
         # This is the compiled code
@@ -317,12 +308,12 @@ class Macro:
         """Write the symbol."""
         # This is done to figure out if the macro is broken at compile time, because
         # if KEY_A was unknown we can show this in the gui before the injection starts.
-        _type_check_symbol(symbol)
+        self._type_check_symbol(symbol)
 
         async def task(handler: Callable):
             # if the code is $foo, figure out the correct code now.
             resolved_symbol = _resolve(symbol, [str])
-            code = _type_check_symbol(resolved_symbol)
+            code = self._type_check_symbol(resolved_symbol)
 
             resolved_code = _resolve(code, [int])
             handler(EV_KEY, resolved_code, 1)
@@ -334,11 +325,11 @@ class Macro:
 
     def add_key_down(self, symbol: str):
         """Press the symbol."""
-        _type_check_symbol(symbol)
+        self._type_check_symbol(symbol)
 
         async def task(handler: Callable):
             resolved_symbol = _resolve(symbol, [str])
-            code = _type_check_symbol(resolved_symbol)
+            code = self._type_check_symbol(resolved_symbol)
 
             resolved_code = _resolve(code, [int])
             handler(EV_KEY, resolved_code, 1)
@@ -347,11 +338,11 @@ class Macro:
 
     def add_key_up(self, symbol: str):
         """Release the symbol."""
-        _type_check_symbol(symbol)
+        self._type_check_symbol(symbol)
 
         async def task(handler: Callable):
             resolved_symbol = _resolve(symbol, [str])
-            code = _type_check_symbol(resolved_symbol)
+            code = self._type_check_symbol(resolved_symbol)
 
             resolved_code = _resolve(code, [int])
             handler(EV_KEY, resolved_code, 0)
@@ -370,11 +361,11 @@ class Macro:
             # if macro is a key name, hold down the key while the
             # keyboard key is physically held down
             symbol = macro
-            _type_check_symbol(symbol)
+            self._type_check_symbol(symbol)
 
             async def task(handler: Callable):
                 resolved_symbol = _resolve(symbol, [str])
-                code = _type_check_symbol(resolved_symbol)
+                code = self._type_check_symbol(resolved_symbol)
 
                 resolved_code = _resolve(code, [int])
                 handler(EV_KEY, resolved_code, 1)
@@ -405,14 +396,14 @@ class Macro:
         macro
         """
         _type_check(macro, [Macro], "modify", 2)
-        _type_check_symbol(modifier)
+        self._type_check_symbol(modifier)
 
         self.child_macros.append(macro)
 
         async def task(handler: Callable):
             # TODO test var
             resolved_modifier = _resolve(modifier, [str])
-            code = _type_check_symbol(resolved_modifier)
+            code = self._type_check_symbol(resolved_modifier)
 
             handler(EV_KEY, code, 1)
             await self._keycode_pause()
@@ -425,11 +416,11 @@ class Macro:
     def add_hold_keys(self, *symbols):
         """Hold down multiple keys, equivalent to `a + b + c + ...`."""
         for symbol in symbols:
-            _type_check_symbol(symbol)
+            self._type_check_symbol(symbol)
 
         async def task(handler: Callable):
             resolved_symbols = [_resolve(symbol, [str]) for symbol in symbols]
-            codes = [_type_check_symbol(symbol) for symbol in resolved_symbols]
+            codes = [self._type_check_symbol(symbol) for symbol in resolved_symbols]
 
             for code in codes:
                 handler(EV_KEY, code, 1)
@@ -698,3 +689,22 @@ class Macro:
                 await else_.run(handler)
 
         self.tasks.append(task)
+
+    def _type_check_symbol(self, keyname: Union[str, Variable]) -> int:
+        """Same as _type_check, but checks if the key-name is valid."""
+        if isinstance(keyname, Variable):
+            # it is a variable and will be read at runtime
+            return keyname
+
+        symbol = str(keyname)
+        code = system_mapping.get(symbol)
+
+        if code is None:
+            raise MacroParsingError(msg=f'Unknown key "{symbol}"')
+
+        if self.mapping is not None:
+            target = self.mapping.target_uinput
+            if target is not None and not can_default_uinput_emit(target, EV_KEY, code):
+                raise SymbolNotAvailableInTargetError(symbol, target)
+
+        return code

--- a/inputremapper/injection/macros/parse.py
+++ b/inputremapper/injection/macros/parse.py
@@ -25,7 +25,7 @@ import inspect
 import re
 from typing import Optional, Any
 
-from inputremapper.exceptions import MacroParsingError
+from inputremapper.configs.validation_errors import MacroParsingError
 from inputremapper.injection.macros.macro import Macro, Variable
 from inputremapper.logger import logger
 
@@ -452,6 +452,7 @@ def parse(macro: str, context=None, mapping=None, verbose: bool = True):
     verbose
         log the parsing True by default
     """
+    # TODO pass mapping in frontend and do the target check for keys?
     logger.debug("parsing macro %s", macro.replace("\n", ""))
     macro = clean(macro)
     macro = handle_plus_syntax(macro)

--- a/readme/coverage.svg
+++ b/readme/coverage.svg
@@ -17,7 +17,7 @@
         <text x="32.5" y="14">coverage</text>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-        <text x="83.0" y="15" fill="#010101" fill-opacity=".3">92%</text>
-        <text x="82.0" y="14">92%</text>
+        <text x="83.0" y="15" fill="#010101" fill-opacity=".3">93%</text>
+        <text x="82.0" y="14">93%</text>
     </g>
 </svg>

--- a/readme/development.md
+++ b/readme/development.md
@@ -87,6 +87,9 @@ sudo pip install .
 New badges, if needed, will be created in `readme/` and they
 just need to be commited.
 
+Beware that coverage can suffer if old files reside in your python path. Remove the build folder
+and reinstall it.
+
 ## Translations
 
 To regenerate the `po/input-remapper.pot` file, run

--- a/readme/pylint.svg
+++ b/readme/pylint.svg
@@ -17,7 +17,7 @@
         <text x="22.0" y="14">pylint</text>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-        <text x="63.0" y="15" fill="#010101" fill-opacity=".3">8.88</text>
-        <text x="62.0" y="14">8.88</text>
+        <text x="63.0" y="15" fill="#010101" fill-opacity=".3">8.87</text>
+        <text x="62.0" y="14">8.87</text>
     </g>
 </svg>

--- a/tests/integration/test_gui.py
+++ b/tests/integration/test_gui.py
@@ -905,8 +905,8 @@ class TestGui(GuiTestBase):
             InputCombination([InputConfig(type=1, code=30, origin_hash=origin)]),
         )
 
-        # 4. update target to mouse
-        self.target_selection.set_active_id("mouse")
+        # 4. update target
+        self.target_selection.set_active_id("keyboard + mouse")
         gtk_iteration()
         self.assertEqual(
             self.data_manager.active_mapping,
@@ -915,20 +915,14 @@ class TestGui(GuiTestBase):
                     [InputConfig(type=1, code=30, origin_hash=origin)]
                 ),
                 output_symbol="Shift_L",
-                target_uinput="mouse",
+                target_uinput="keyboard + mouse",
             ),
         )
 
     def test_show_status(self):
-        self.message_broker.publish(StatusData(0, "a" * 500))
-        gtk_iteration()
+        self.message_broker.publish(StatusData(0, "a"))
         text = self.get_status_text()
-        self.assertIn("...", text)
-
-        self.message_broker.publish(StatusData(0, "b"))
-        gtk_iteration()
-        text = self.get_status_text()
-        self.assertNotIn("...", text)
+        self.assertEqual("a", text)
 
     def test_hat_switch(self):
         # load a device with more capabilities

--- a/tests/unit/test_mapping.py
+++ b/tests/unit/test_mapping.py
@@ -28,6 +28,7 @@ from evdev.ecodes import (
     REL_Y,
     REL_WHEEL,
     REL_WHEEL_HI_RES,
+    KEY_1,
 )
 from pydantic import ValidationError
 
@@ -369,60 +370,62 @@ class TestMapping(unittest.IsolatedAsyncioTestCase):
 
 class TestUIMapping(unittest.IsolatedAsyncioTestCase):
     def test_init(self):
-        """should be able to initialize without an error"""
+        """Should be able to initialize without throwing errors."""
         UIMapping()
 
     def test_is_valid(self):
-        """should be invalid at first
-        and become valid once all data is provided"""
-        m = UIMapping()
-        self.assertFalse(m.is_valid())
+        """Should be invalid at first and become valid once all data is provided."""
+        mapping = UIMapping()
+        self.assertFalse(mapping.is_valid())
 
-        m.input_combination = [{"type": 1, "code": 2}]
-        m.output_symbol = "a"
-        self.assertFalse(m.is_valid())
-        m.target_uinput = "keyboard"
-        self.assertTrue(m.is_valid())
+        mapping.input_combination = [{"type": EV_KEY, "code": KEY_1}]
+        mapping.output_symbol = "a"
+        self.assertFalse(mapping.is_valid())
+        mapping.target_uinput = "keyboard"
+        self.assertTrue(mapping.is_valid())
 
     def test_updates_validation_error(self):
-        m = UIMapping()
-        self.assertGreaterEqual(len(m.get_error().errors()), 2)
-        m.input_combination = [{"type": 1, "code": 2}]
-        m.output_symbol = "a"
+        mapping = UIMapping()
+        self.assertGreaterEqual(len(mapping.get_error().errors()), 2)
+        mapping.input_combination = [{"type": EV_KEY, "code": KEY_1}]
+        mapping.output_symbol = "a"
         self.assertIn(
-            "1 validation error for Mapping\ntarget_uinput", str(m.get_error())
+            "1 validation error for Mapping\ntarget_uinput",
+            str(mapping.get_error()),
         )
-        m.target_uinput = "keyboard"
-        self.assertTrue(m.is_valid())
-        self.assertIsNone(m.get_error())
+        mapping.target_uinput = "keyboard"
+        self.assertTrue(mapping.is_valid())
+        self.assertIsNone(mapping.get_error())
 
     def test_copy_returns_ui_mapping(self):
-        """copy should also be a UIMapping with all the invalid data"""
-        m = UIMapping()
-        m2 = m.copy()
-        self.assertIsInstance(m2, UIMapping)
-        self.assertEqual(m2.input_combination, InputCombination.empty_combination())
-        self.assertIsNone(m2.output_symbol)
+        """Copy should also be a UIMapping with all the invalid data."""
+        mapping = UIMapping()
+        mapping_2 = mapping.copy()
+        self.assertIsInstance(mapping_2, UIMapping)
+        self.assertEqual(
+            mapping_2.input_combination, InputCombination.empty_combination()
+        )
+        self.assertIsNone(mapping_2.output_symbol)
 
     def test_get_bus_massage(self):
-        m = UIMapping()
-        m2 = m.get_bus_message()
-        self.assertEqual(m2.message_type, MessageType.mapping)
+        mapping = UIMapping()
+        mapping_2 = mapping.get_bus_message()
+        self.assertEqual(mapping_2.message_type, MessageType.mapping)
 
         with self.assertRaises(TypeError):
             # the massage should be immutable
-            m2.output_symbol = "a"
-        self.assertIsNone(m2.output_symbol)
+            mapping_2.output_symbol = "a"
+        self.assertIsNone(mapping_2.output_symbol)
 
         # the original should be not immutable
-        m.output_symbol = "a"
-        self.assertEqual(m.output_symbol, "a")
+        mapping.output_symbol = "a"
+        self.assertEqual(mapping.output_symbol, "a")
 
     def test_has_input_defined(self):
-        m = UIMapping()
-        self.assertFalse(m.has_input_defined())
-        m.input_combination = InputCombination([InputConfig(type=EV_KEY, code=1)])
-        self.assertTrue(m.has_input_defined())
+        mapping = UIMapping()
+        self.assertFalse(mapping.has_input_defined())
+        mapping.input_combination = InputCombination([InputConfig(type=EV_KEY, code=1)])
+        self.assertTrue(mapping.has_input_defined())
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_mapping.py
+++ b/tests/unit/test_mapping.py
@@ -367,6 +367,44 @@ class TestMapping(unittest.IsolatedAsyncioTestCase):
         m = Mapping(**cfg)
         self.assertTrue(m.is_valid())
 
+    def test_wrong_target(self):
+        mapping = Mapping(
+            input_combination=[{"type": EV_KEY, "code": KEY_1}],
+            target_uinput="keyboard",
+            output_symbol="a",
+        )
+        mapping.set_combination_changed_callback(lambda *args: None)
+        self.assertRaisesRegex(
+            ValidationError,
+            # the error should mention
+            # - the symbol
+            # - the current incorrect target
+            # - the target that works for this symbol
+            ".*BTN_A.*keyboard.*gamepad",
+            mapping.__setattr__,
+            "output_symbol",
+            "BTN_A",
+        )
+
+    def test_wrong_target_for_macro(self):
+        mapping = Mapping(
+            input_combination=[{"type": EV_KEY, "code": KEY_1}],
+            target_uinput="keyboard",
+            output_symbol="key(a)",
+        )
+        mapping.set_combination_changed_callback(lambda *args: None)
+        self.assertRaisesRegex(
+            ValidationError,
+            # the error should mention
+            # - the symbol
+            # - the current incorrect target
+            # - the target that works for this symbol
+            ".*BTN_A.*keyboard.*gamepad",
+            mapping.__setattr__,
+            "output_symbol",
+            "key(BTN_A)",
+        )
+
 
 class TestUIMapping(unittest.IsolatedAsyncioTestCase):
     def test_init(self):

--- a/tests/unit/test_preset.py
+++ b/tests/unit/test_preset.py
@@ -426,7 +426,7 @@ class TestPreset(unittest.TestCase):
         mapping.output_symbol = "BTN_Left"
         self.assertFalse(self.preset.dangerously_mapped_btn_left())
 
-        mapping.target_uinput = "keyboard"
+        mapping.target_uinput = "keyboard + mouse"
         mapping.output_symbol = "3"
         self.assertTrue(self.preset.dangerously_mapped_btn_left())
 


### PR DESCRIPTION
closes #468

- Displays the error in the status bar directly, if there is only one
- the `__root__` substring is omitted from errors in the gui
- using gtks ellipsis functionality
- the error-icon was invisible when the application was loading
- the error lookup is not using redundant strings anymore
- checks for wrong targets in macro parameters
- Adds a helpful error message if the target is incorrect:

![image](https://user-images.githubusercontent.com/28510156/221353953-3f401708-0073-4c9d-8dc1-2a94a6a74208.png)
