### PR TITLE
Fix btn left confusion

### DIFF
--- a/inputremapper/configs/preset.py
+++ b/inputremapper/configs/preset.py
@@ -232,15 +232,6 @@ class Preset(Generic[MappingModel]):
             existing = self._mappings.get(permutation)
             if existing is not None:
                 return existing
-
-        logger.error(
-            "Combination %s not found. Available: %s",
-            repr(combination),
-            list(
-                self._mappings.keys(),
-            ),
-        )
-
         return None
 
     def dangerously_mapped_btn_left(self) -> bool:

--- a/inputremapper/configs/preset.py
+++ b/inputremapper/configs/preset.py
@@ -236,7 +236,7 @@ class Preset(Generic[MappingModel]):
 
     def dangerously_mapped_btn_left(self) -> bool:
         """Return True if this mapping disables BTN_Left."""
-        if InputConfig.btn_left().type_and_code not in [
+        if (ecodes.EV_KEY, ecodes.BTN_LEFT) not in [
             m.input_combination[0].type_and_code for m in self
         ]:
             return False

--- a/inputremapper/configs/preset.py
+++ b/inputremapper/configs/preset.py
@@ -236,8 +236,8 @@ class Preset(Generic[MappingModel]):
 
     def dangerously_mapped_btn_left(self) -> bool:
         """Return True if this mapping disables BTN_Left."""
-        if InputCombination([InputConfig.btn_left()]) not in [
-            m.input_combination for m in self
+        if InputConfig.btn_left().type_and_code not in [
+            m.input_combination[0].type_and_code for m in self
         ]:
             return False
 

--- a/inputremapper/gui/controller.py
+++ b/inputremapper/gui/controller.py
@@ -655,9 +655,7 @@ class Controller:
 
         def running():
             msg = _("Applied preset %s") % self.data_manager.active_preset.name
-            if self.data_manager.active_preset.get_mapping(
-                InputCombination([InputConfig.btn_left()])
-            ):
+            if self.data_manager.active_preset.dangerously_mapped_btn_left():
                 msg += _(", CTRL + DEL to stop")
             self.show_status(CTX_APPLY, msg)
             logger.info(

--- a/inputremapper/gui/data_manager.py
+++ b/inputremapper/gui/data_manager.py
@@ -329,10 +329,13 @@ class DataManager:
 
         mapping = self._active_preset.get_mapping(combination)
         if not mapping:
-            raise KeyError(
+            msg = (
                 f"the mapping with {combination = } does not "
                 f"exist in the {self._active_preset.path}"
             )
+            logger.error(msg)
+            raise KeyError(msg)
+
         self._active_input_config = None
         self._active_mapping = mapping
         self.publish_mapping()


### PR DESCRIPTION
#710 exposed an issue where an error would be logged, whenever a preset was applied due to the GUI check for `BTN_LEFT`. 
The check for `BTN_LEFT` was broken due to the introduction of `origin_hash`.