### PR TITLE
Using asyncio.run instead of loop.run_until_complete

### DIFF
--- a/bin/input-remapper-reader-service
+++ b/bin/input-remapper-reader-service
@@ -55,5 +55,4 @@ if __name__ == '__main__':
     atexit.register(on_exit)
     groups = _Groups()
     reader_service = ReaderService(groups)
-    loop = asyncio.new_event_loop()
-    loop.run_until_complete(reader_service.run())
+    asyncio.run(reader_service.run())


### PR DESCRIPTION
Fixes https://github.com/sezanzeb/input-remapper/issues/723#issuecomment-1605930777