### PR TITLE
Fix pydantic error (allow pydantic v1 and v2 at the same time)

### DIFF
--- a/inputremapper/configs/input_config.py
+++ b/inputremapper/configs/input_config.py
@@ -25,7 +25,11 @@ from typing import Tuple, Iterable, Union, List, Dict, Optional, Hashable, NewTy
 from evdev import ecodes
 
 from inputremapper.input_event import InputEvent
-from pydantic import BaseModel, root_validator, validator
+
+try:
+    from pydantic.v1 import BaseModel, root_validator, validator
+except ImportError:
+    from pydantic import BaseModel, root_validator, validator
 
 from inputremapper.configs.system_mapping import system_mapping
 from inputremapper.gui.messages.message_types import MessageType

--- a/inputremapper/configs/mapping.py
+++ b/inputremapper/configs/mapping.py
@@ -33,18 +33,33 @@ from evdev.ecodes import (
     REL_HWHEEL_HI_RES,
     REL_WHEEL_HI_RES,
 )
-from pydantic import (
-    BaseModel,
-    PositiveInt,
-    confloat,
-    conint,
-    root_validator,
-    validator,
-    ValidationError,
-    PositiveFloat,
-    VERSION,
-    BaseConfig,
-)
+
+try:
+    from pydantic.v1 import (
+        BaseModel,
+        PositiveInt,
+        confloat,
+        conint,
+        root_validator,
+        validator,
+        ValidationError,
+        PositiveFloat,
+        VERSION,
+        BaseConfig,
+    )
+except ImportError:
+    from pydantic import (
+        BaseModel,
+        PositiveInt,
+        confloat,
+        conint,
+        root_validator,
+        validator,
+        ValidationError,
+        PositiveFloat,
+        VERSION,
+        BaseConfig,
+    )
 
 from inputremapper.configs.input_config import InputCombination
 from inputremapper.configs.system_mapping import system_mapping, DISABLE_NAME

--- a/inputremapper/configs/preset.py
+++ b/inputremapper/configs/preset.py
@@ -36,7 +36,10 @@ from typing import (
     overload,
 )
 
-from pydantic import ValidationError
+try:
+    from pydantic.v1 import ValidationError
+except ImportError:
+    from pydantic import ValidationError
 
 from inputremapper.configs.input_config import InputCombination, InputConfig
 from inputremapper.configs.mapping import Mapping, UIMapping

--- a/tests/unit/test_injector.py
+++ b/tests/unit/test_injector.py
@@ -18,7 +18,10 @@
 # You should have received a copy of the GNU General Public License
 # along with input-remapper.  If not, see <https://www.gnu.org/licenses/>.
 
-from pydantic import ValidationError
+try:
+    from pydantic.v1 import ValidationError
+except ImportError:
+    from pydantic import ValidationError
 
 from inputremapper.input_event import InputEvent
 from tests.lib.global_uinputs import (

--- a/tests/unit/test_mapping.py
+++ b/tests/unit/test_mapping.py
@@ -30,7 +30,11 @@ from evdev.ecodes import (
     REL_WHEEL_HI_RES,
     KEY_1,
 )
-from pydantic import ValidationError
+
+try:
+    from pydantic.v1 import ValidationError
+except ImportError:
+    from pydantic import ValidationError
 
 from inputremapper.configs.mapping import Mapping, UIMapping
 from inputremapper.configs.system_mapping import system_mapping, DISABLE_NAME


### PR DESCRIPTION
## The Issue

* #769

## How This PR Solves The Issue

Input Remapper can continue to use pydantic v1 syntax because pydantic v2 allows it (see https://docs.pydantic.dev/2.3/migration/#continue-using-pydantic-v1-features)

I have added imports for pydantic v2 by default, and imports for pydantic v1 will be used as a fallback.