### PR TITLE
Adds layer implementations to examples.md

### DIFF
--- a/readme/examples.md
+++ b/readme/examples.md
@@ -178,55 +178,30 @@ xmodmap keyboard_layout
 again for the injection to use that xmodmap as well. It should be possible
 to write "ヤ" now when pressing the key.
 
-##Implementing Layers
+## Implementing Layers
 
-To implement layer functionality (like QMK) we can use the `set` and `if_eq` macros.
+We can implement layer functionality (similar to QMK) using the `set` and `if_eq` macros.
 
-```
-A: set(foo, 0)
-B: set(foo, 1)
-X: if_eq(
-    foo,1,
-    hold_keys(Y),
-    Hold_keys(X)
-    )
-```
+- `A`: `set(foo, 0)`
+- `B`: `set(foo, 1)`
+- `X`: `if_eq(foo, 1, hold_keys(Y), hold_keys(X))`
 
-Pressing `A` sets `$foo=0`, pressing `B` sets `$foo=1`. `X` is `Y` if `$foo=1`, otherwise `X` is `X`. Pressing `A > X > B > X` will output XY
+Pressing `A` sets `$foo=0`, pressing `B` sets `$foo=1`. `X` is `Y` if `$foo=1`, otherwise `X` is `X`. Pressing `A` > `X` > `B` > `X` will output `XY`.
 
 
 
 We can implement a single layer toggle macro which can be used to switch back and forth betwixt layers.
 
-```
-A: if_eq(
-  foo, 1,
-  set(foo, 0),
-  set(foo, 1)
-  )
+- `A`:`if_eq(foo, 1, set(foo, 0), set(foo, 1))`
+- `X`:`if_eq(foo, 1, hold_keys(Y), hold_keys(X))`
 
-X: if_eq(
-    foo,1,
-    hold_keys(Y),
-    Hold_keys(X)
-    )
-```
-
-Pressing `A` will now toggle between `$foo=0` and `$foo=1`. So pressing `X > A > X` will output `XY` (or `YX` if you start from `$foo=1`).
-
+Pressing `A` toggles between `$foo=0` and `$foo=1`. So pressing `X` > `A` > `X` will output `XY` (or `YX` if you start from `$foo=1`).
 
 
 We can create layer-shift macros that will enable the layer only while being held.
 
-```
-A: set(foo, 1).hold().set(foo, 0)
-
-X: if_eq(
-    foo,1,
-    hold_keys(Y),
-    Hold_keys(X)
-    )
-```
+- `A`:`set(foo, 1).hold().set(foo, 0)`
+- `X`:`if_eq(foo, 1, hold_keys(Y), hold_keys(X))`
 
 This will set `$foo=1` only while `A` is held down. Pressing `X` will output `X` but holding `A` while pressing `X` will output `Y`. 
 
@@ -234,28 +209,9 @@ We can extend this further to create second (and third, fourth, etc...) layer ma
 
 For example creating a Vim HJKL movement layer when `left Alt` is held down.
 
-```
-Alt_L: set(layer, 1).hold().set(layer, 0)
-H: ifeq(
-    layer, 1,
-    hold_keys(Left), 
-    hold_keys(H)
-  )
-J: ifeq(
-    layer, 1,
-    hold_keys(Down), 
-    hold_keys(J)
-  )
-K: ifeq(
-    layer, 1,
-    hold_keys(Up), 
-    hold_keys(K)
-  )
-L: ifeq(
-    layer, 1,
-    hold_keys(Right), 
-    hold_keys(L)
-  )
-
-``` 
+- `Alt_L`:`set(layer, 1).hold().set(layer, 0)`
+- `H`:`ifeq(layer, 1, hold_keys(Left), hold_keys(H))`
+- `J`:`ifeq(layer, 1, hold_keys(Down), hold_keys(J))`
+- `K`:`ifeq(layer, 1, hold_keys(Up), hold_keys(K))`
+- `L`:`ifeq(layer, 1, hold_keys(Right), hold_keys(L))`
 

--- a/readme/examples.md
+++ b/readme/examples.md
@@ -190,7 +190,7 @@ Pressing `A` sets `$foo=0`, pressing `B` sets `$foo=1`. `X` is `Y` if `$foo=1`, 
 
 
 
-We can implement a single layer toggle macro which can be used to switch back and forth betwixt layers.
+We can implement a single macro to toggle back and forth betwixt layers.
 
 - `A`:`if_eq(foo, 1, set(foo, 0), set(foo, 1))`
 - `X`:`if_eq(foo, 1, hold_keys(Y), hold_keys(X))`

--- a/readme/examples.md
+++ b/readme/examples.md
@@ -177,3 +177,85 @@ xmodmap keyboard_layout
 
 again for the injection to use that xmodmap as well. It should be possible
 to write "ヤ" now when pressing the key.
+
+##Implementing Layers
+
+To implement layer functionality (like QMK) we can use the `set` and `if_eq` macros.
+
+```
+A: set(foo, 0)
+B: set(foo, 1)
+X: if_eq(
+    foo,1,
+    hold_keys(Y),
+    Hold_keys(X)
+    )
+```
+
+Pressing `A` sets `$foo=0`, pressing `B` sets `$foo=1`. `X` is `Y` if `$foo=1`, otherwise `X` is `X`. Pressing `A > X > B > X` will output XY
+
+
+
+We can implement a single layer toggle macro which can be used to switch back and forth betwixt layers.
+
+```
+A: if_eq(
+  foo, 1,
+  set(foo, 0),
+  set(foo, 1)
+  )
+
+X: if_eq(
+    foo,1,
+    hold_keys(Y),
+    Hold_keys(X)
+    )
+```
+
+Pressing `A` will now toggle between `$foo=0` and `$foo=1`. So pressing `X > A > X` will output `XY` (or `YX` if you start from `$foo=1`).
+
+
+
+We can create layer-shift macros that will enable the layer only while being held.
+
+```
+A: set(foo, 1).hold().set(foo, 0)
+
+X: if_eq(
+    foo,1,
+    hold_keys(Y),
+    Hold_keys(X)
+    )
+```
+
+This will set `$foo=1` only while `A` is held down. Pressing `X` will output `X` but holding `A` while pressing `X` will output `Y`. 
+
+We can extend this further to create second (and third, fourth, etc...) layer macros for the entire keyboard.
+
+For example creating a Vim HJKL movement layer when `left Alt` is held down.
+
+```
+Alt_L: set(layer, 1).hold().set(layer, 0)
+H: ifeq(
+    layer, 1,
+    hold_keys(Left), 
+    hold_keys(H)
+  )
+J: ifeq(
+    layer, 1,
+    hold_keys(Down), 
+    hold_keys(J)
+  )
+K: ifeq(
+    layer, 1,
+    hold_keys(Up), 
+    hold_keys(K)
+  )
+L: ifeq(
+    layer, 1,
+    hold_keys(Right), 
+    hold_keys(L)
+  )
+
+``` 
+


### PR DESCRIPTION
This just adds some examples for people looking to implement switch/toggle/shift layer macros. I'm just doing the documentation, credit to @sezanzeb for actually figuring out how to implement layers (https://github.com/sezanzeb/input-remapper/issues/91#issuecomment-819005454) and layer toggle (https://github.com/sezanzeb/input-remapper/issues/91#issuecomment-826360430).