### PR TITLE
docs: remove redundant install step on Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ input-remapper ≥ 2.0 requires at least Ubuntu 22.04.
 ```bash
 sudo dnf install input-remapper
 sudo systemctl enable --now input-remapper
-sudo systemctl start input-remapper
 ```
 
 ##### Manual


### PR DESCRIPTION
The `--now` flag to `systemctl enable` already starts the service immediately, no need to run a start command again.