### PR TITLE
Install icon to standard path, fix appstream-builder generation

### DIFF
--- a/data/input-remapper-autoload.desktop
+++ b/data/input-remapper-autoload.desktop
@@ -2,5 +2,5 @@
 Type=Application
 Exec=bash -c "input-remapper-control --command stop-all && input-remapper-control --command autoload"
 Name=input-remapper-autoload
-Icon=/usr/share/input-remapper/input-remapper.svg
+Icon=input-remapper
 Comment=Starts injecting all presets that are set to automatically load for the user

--- a/data/input-remapper-gtk.desktop
+++ b/data/input-remapper-gtk.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=Input Remapper
-Icon=/usr/share/input-remapper/input-remapper.svg
+Icon=input-remapper
 Exec=input-remapper-gtk
 Terminal=false
 Categories=Settings

--- a/setup.py
+++ b/setup.py
@@ -119,6 +119,7 @@ setup(
             "/usr/share/metainfo/",
             ["data/io.github.sezanzeb.input_remapper.metainfo.xml"],
         ),
+        ("/usr/share/icons/hicolor/scalable/apps/", ["data/input-remapper.svg"]),
         ("/usr/share/polkit-1/actions/", ["data/input-remapper.policy"]),
         ("/usr/lib/systemd/system", ["data/input-remapper.service"]),
         ("/etc/dbus-1/system.d/", ["data/inputremapper.Control.conf"]),


### PR DESCRIPTION
appstream-builder was failing to generate the appstream metainfo from this package as it didn't provide an icon in a standard path.

appstream-builder states:
> Icons MUST be installed in /usr/share/pixmaps/*, /usr/share/icons/*,
> /usr/share/icons/hicolor/*/apps/*, or /usr/share/${app_name}/icons/*