### PR TITLE
Do not exclude buttonless devices that have axes

### DIFF
--- a/inputremapper/groups.py
+++ b/inputremapper/groups.py
@@ -389,11 +389,7 @@ class _FindGroups(threading.Thread):
             abs_capa = capabilities.get(EV_ABS)
             rel_capa = capabilities.get(EV_REL)
 
-            if (
-                key_capa is None
-                and abs_capa is None
-                and rel_capa is None
-            ):
+            if key_capa is None and abs_capa is None and rel_capa is None:
                 # skip devices that don't provide buttons or axes that can be mapped
                 logger.debug('"%s" has no useful capabilities', device.name)
                 continue

--- a/inputremapper/groups.py
+++ b/inputremapper/groups.py
@@ -389,7 +389,12 @@ class _FindGroups(threading.Thread):
             abs_capa = capabilities.get(EV_ABS)
             rel_capa = capabilities.get(EV_REL)
             
-            if key_capa is None and abs_capa is None and rel_capa is None and device_type != DeviceType.GAMEPAD:
+            if (
+                key_capa is None
+                and abs_capa is None
+                and rel_capa is None
+                and device_type != DeviceType.GAMEPAD
+            ):
                 # skip devices that don't provide buttons or axes that can be mapped
                 logger.debug('"%s" has no useful capabilities', device.name)
                 continue

--- a/inputremapper/groups.py
+++ b/inputremapper/groups.py
@@ -388,12 +388,11 @@ class _FindGroups(threading.Thread):
             key_capa = capabilities.get(EV_KEY)
             abs_capa = capabilities.get(EV_ABS)
             rel_capa = capabilities.get(EV_REL)
-            
+
             if (
                 key_capa is None
                 and abs_capa is None
                 and rel_capa is None
-                and device_type != DeviceType.GAMEPAD
             ):
                 # skip devices that don't provide buttons or axes that can be mapped
                 logger.debug('"%s" has no useful capabilities', device.name)

--- a/inputremapper/groups.py
+++ b/inputremapper/groups.py
@@ -386,9 +386,11 @@ class _FindGroups(threading.Thread):
             capabilities = device.capabilities(absinfo=False)
 
             key_capa = capabilities.get(EV_KEY)
-
-            if key_capa is None and device_type != DeviceType.GAMEPAD:
-                # skip devices that don't provide buttons that can be mapped
+            abs_capa = capabilities.get(EV_ABS)
+            rel_capa = capabilities.get(EV_REL)
+            
+            if key_capa is None and abs_capa is None and rel_capa is None and device_type != DeviceType.GAMEPAD:
+                # skip devices that don't provide buttons or axes that can be mapped
                 logger.debug('"%s" has no useful capabilities', device.name)
                 continue
 

--- a/tests/unit/test_groups.py
+++ b/tests/unit/test_groups.py
@@ -180,9 +180,8 @@ class TestGroups(unittest.TestCase):
         self.assertIsNotNone(groups.find(name="gamepad"))
 
     def test_device_with_only_ev_abs(self):
-        # could be anything, a lot of devices have ABS_X capabilities,
-        # so it is not treated as gamepad joystick and since it also
-        # doesn't have key capabilities, there is nothing to map.
+        # As Input Mapper can now map axes to buttons,
+        # a single EV_ABS device is valid for mapping.
         fixtures["/foo/bar"] = {
             "name": "qux",
             "phys": "abcd2",
@@ -192,12 +191,19 @@ class TestGroups(unittest.TestCase):
 
         groups.refresh()
         self.assertIsNotNone(groups.find(name="gamepad"))
-        self.assertIsNone(groups.find(name="qux"))
-
-        # verify this test even works at all
-        fixtures["/foo/bar"].capabilities[EV_KEY] = [KEY_A]
-        groups.refresh()
         self.assertIsNotNone(groups.find(name="qux"))
+
+    def test_device_with_no_capabilities(self):
+        fixtures["/foo/bar"] = {
+            "name": "nulcap",
+            "phys": "abcd3",
+            "info": evdev.DeviceInfo(1, 2, 3, 4),
+            "capabilities": {},
+        }
+
+        groups.refresh()
+        self.assertIsNotNone(groups.find(name="gamepad"))
+        self.assertIsNone(groups.find(name="nulcap"))
 
     def test_duplicate_device(self):
         fixtures["/dev/input/event100"] = {


### PR DESCRIPTION
Changes to groups.py to enable devices such as racing pedals (which have multiple axes but no buttons) to be remapped in the GUI.