### PR TITLE
Fixing debug log source file for written keys

### DIFF
--- a/inputremapper/logger.py
+++ b/inputremapper/logger.py
@@ -102,7 +102,7 @@ class Logger(logging.Logger):
 
         previous_write_debug_log = msg
 
-        self._log(logging.DEBUG, msg, args=None)
+        self._log(logging.DEBUG, msg, args=None, stacklevel=2)
 
 
 # https://github.com/python/typeshed/issues/1801


### PR DESCRIPTION
Before:

```
14:45:30.833605 18820 service DEBUG logger.py:105: Writing <InputEvent for (1, 125, 1) KEY_LEFTMETA at 0x76a70af73e60> to "input-remapper Logitech USB Keyboard forwarded"
14:45:31.177502 18820 service DEBUG combination_handler.py:138: Sending Combination (InputConfig KEY_LEFTMETA + InputConfig KEY_O) to sub-handler
14:45:31.177657 18820 service DEBUG logger.py:105: Writing (1, 115, 1) to "input-remapper keyboard"
14:45:31.265480 18820 service DEBUG combination_handler.py:138: Sending Combination (InputConfig KEY_LEFTMETA + InputConfig KEY_O) to sub-handler
14:45:31.265611 18820 service DEBUG logger.py:105: Writing (1, 115, 0) to "input-remapper keyboard"
```

after:

```
14:48:05.482275 19625 service DEBUG event_reader.py:165: Writing <InputEvent for (1, 125, 1) KEY_LEFTMETA at 0x7aec4c69f8c0> to "input-remapper Logitech USB Keyboard forwarded"
14:48:05.857964 19625 service DEBUG combination_handler.py:138: Sending Combination (InputConfig KEY_LEFTMETA + InputConfig KEY_O) to sub-handler
14:48:05.858107 19625 service DEBUG global_uinputs.py:181: Writing (1, 115, 1) to "input-remapper keyboard"
14:48:05.945917 19625 service DEBUG combination_handler.py:138: Sending Combination (InputConfig KEY_LEFTMETA + InputConfig KEY_O) to sub-handler
14:48:05.946015 19625 service DEBUG global_uinputs.py:181: Writing (1, 115, 0) to "input-remapper keyboard"
```

`logger.py:105` is replaced with the correct source file and line now