### PR TITLE
Added optional wait variance

### DIFF
--- a/inputremapper/injection/macros/macro.py
+++ b/inputremapper/injection/macros/macro.py
@@ -541,22 +541,22 @@ class Macro:
 
         self.tasks.append(task)
 
-    def add_wait(self, time: Union[str, int, float], max_time=None):
+    def add_wait(self, time: Union[str, float, int], max_time=None):
         """Wait time in milliseconds."""
-        time = _type_check(time, [int, float], "wait", 1)
-        max_time = _type_check(max_time, [int, float, None], "wait", 2)
+        time = _type_check(time, [float, int], "wait", 1)
+        max_time = _type_check(max_time, [float, int, None], "wait", 2)
 
         async def task(_):
-            resolved_min_time = _resolve(time, [int, float])
-            resolved_max_time = _resolve(max_time, [int, float])
+            resolved_min_time = _resolve(time, [float, int])
+            resolved_max_time = _resolve(max_time, [float, int])
 
             if resolved_max_time is not None and resolved_max_time > resolved_min_time:
-                logger.debug('Wait time is between "%f" and "%f"ms', resolved_min_time, resolved_max_time)
                 variabletime = random.uniform(resolved_min_time, resolved_max_time)
+                logger.debug('Wait time %f <= [%f] <= %fms', resolved_min_time, variabletime, resolved_max_time)
             else:
                 variabletime = resolved_min_time
+                logger.debug('Wait time used is %fms', variabletime)
 
-            logger.debug('Wait time used is "%f"ms', variabletime)
 
             await asyncio.sleep(variabletime / 1000)
 

--- a/inputremapper/injection/macros/macro.py
+++ b/inputremapper/injection/macros/macro.py
@@ -546,16 +546,16 @@ class Macro:
         time = _type_check(time, [int], "wait", 1)
         max_time = _type_check(max_time, [int], "wait", 2)
 
-        time = _resolve(time, [int])
-        max_time = _resolve(max_time, [int])
-
         async def task(_):
-            if max_time > time:
-                time_vary = random.randint(time, max_time)
-            else:
-                time_vary = time
+            resolved_min_time = _resolve(time, [int])
+            resolved_max_time = _resolve(max_time, [int])
 
-            await asyncio.sleep(time_vary / 1000)
+            if resolved_max_time > resolved_min_time:
+                variabletime = random.randint(resolved_min_time, resolved_max_time)
+            else:
+                variabletime = resolved_min_time
+
+            await asyncio.sleep(variabletime / 1000)
 
         self.tasks.append(task)
 

--- a/inputremapper/injection/macros/macro.py
+++ b/inputremapper/injection/macros/macro.py
@@ -544,7 +544,7 @@ class Macro:
     def add_wait(self, time: Union[str, int], max_time=None):
         """Wait time in milliseconds."""
         time = _type_check(time, [int], "wait", 1)
-        max_time = _type_check(max_time, [int], "wait", 2)
+        max_time = _type_check(max_time, [int,None], "wait", 2)
 
         async def task(_):
             resolved_min_time = _resolve(time, [int])

--- a/inputremapper/injection/macros/macro.py
+++ b/inputremapper/injection/macros/macro.py
@@ -541,19 +541,22 @@ class Macro:
 
         self.tasks.append(task)
 
-    def add_wait(self, time: Union[str, int], max_time=None):
+    def add_wait(self, time: Union[str, int, float], max_time=None):
         """Wait time in milliseconds."""
-        time = _type_check(time, [int], "wait", 1)
-        max_time = _type_check(max_time, [int,None], "wait", 2)
+        time = _type_check(time, [int, float], "wait", 1)
+        max_time = _type_check(max_time, [int, float, None], "wait", 2)
 
         async def task(_):
-            resolved_min_time = _resolve(time, [int])
-            resolved_max_time = _resolve(max_time, [int])
+            resolved_min_time = _resolve(time, [int, float])
+            resolved_max_time = _resolve(max_time, [int, float])
 
             if resolved_max_time is not None and resolved_max_time > resolved_min_time:
-                variabletime = random.randint(resolved_min_time, resolved_max_time)
+                logger.debug('Wait time is between "%f" and "%f"ms', resolved_min_time, resolved_max_time)
+                variabletime = random.uniform(resolved_min_time, resolved_max_time)
             else:
                 variabletime = resolved_min_time
+
+            logger.debug('Wait time used is "%f"ms', variabletime)
 
             await asyncio.sleep(variabletime / 1000)
 

--- a/inputremapper/injection/macros/macro.py
+++ b/inputremapper/injection/macros/macro.py
@@ -541,18 +541,21 @@ class Macro:
 
         self.tasks.append(task)
 
-    def add_wait(self, time: Union[str, int], vary: int=0):
+    def add_wait(self, time: Union[str, int], max_time: int=0):
         """Wait time in milliseconds."""
         time = _type_check(time, [int], "wait", 1)
-        vary = _type_check(vary, [int], "wait", 2)
+        max_time = _type_check(max_time, [int], "wait", 2)
+
+        time = _resolve(time, [int])
+        max_time = _resolve(max_time, [int])
 
         async def task(_):
-            if _resolve(vary, [int]) > _resolve(time, [int]):
-                time_vary = random.randint(_resolve(time, [int]), _resolve(vary, [int]))
+            if max_time > time:
+                time_vary = random.randint(time, max_time)
             else:
-                time_vary = _resolve(time, [int])
+                time_vary = time
 
-            await asyncio.sleep(_resolve(time_vary, [int, float]) / 1000)
+            await asyncio.sleep(time_vary / 1000)
 
         self.tasks.append(task)
 

--- a/inputremapper/injection/macros/macro.py
+++ b/inputremapper/injection/macros/macro.py
@@ -40,6 +40,7 @@ import asyncio
 import copy
 import math
 import re
+import random
 from typing import List, Callable, Awaitable, Tuple, Optional, Union, Any
 
 from evdev.ecodes import (
@@ -540,12 +541,18 @@ class Macro:
 
         self.tasks.append(task)
 
-    def add_wait(self, time: Union[int, float]):
+    def add_wait(self, time: Union[str, int], vary: int=0):
         """Wait time in milliseconds."""
-        time = _type_check(time, [int, float], "wait", 1)
+        time = _type_check(time, [int], "wait", 1)
+        vary = _type_check(vary, [int], "wait", 2)
 
         async def task(_):
-            await asyncio.sleep(_resolve(time, [int, float]) / 1000)
+            if _resolve(vary, [int]) > _resolve(time, [int]):
+                time_vary = random.randint(_resolve(time, [int]), _resolve(vary, [int]))
+            else:
+                time_vary = _resolve(time, [int])
+
+            await asyncio.sleep(_resolve(time_vary, [int, float]) / 1000)
 
         self.tasks.append(task)
 

--- a/inputremapper/injection/macros/macro.py
+++ b/inputremapper/injection/macros/macro.py
@@ -541,7 +541,7 @@ class Macro:
 
         self.tasks.append(task)
 
-    def add_wait(self, time: Union[str, int], max_time: int=0):
+    def add_wait(self, time: Union[str, int], max_time=None):
         """Wait time in milliseconds."""
         time = _type_check(time, [int], "wait", 1)
         max_time = _type_check(max_time, [int], "wait", 2)
@@ -550,7 +550,7 @@ class Macro:
             resolved_min_time = _resolve(time, [int])
             resolved_max_time = _resolve(max_time, [int])
 
-            if resolved_max_time > resolved_min_time:
+            if resolved_max_time is not None and resolved_max_time > resolved_min_time:
                 variabletime = random.randint(resolved_min_time, resolved_max_time)
             else:
                 variabletime = resolved_min_time

--- a/tests/unit/test_macros.py
+++ b/tests/unit/test_macros.py
@@ -919,34 +919,76 @@ class TestMacros(MacroTestBase):
         macro = parse("wait(10).key(1)", self.context, DummyMapping, True)
         one_code = system_mapping.get("1")
 
-        await macro.run(self.handler)
-        self.assertListEqual(
-            self.result,
-            [(EV_KEY, one_code, 1), (EV_KEY, one_code, 0)],
-        )
-        self.assertEqual(len(macro.child_macros), 0)
+        minTime = 999999
+        maxTime = 0
+        its = 10
+        totalStart = time.time()
+        for loopcount in range(its):
+            runStart = time.time()
+            await macro.run(self.handler)
+            runEnd = time.time()
+            runTime = runEnd - runStart
+            if runTime < minTime:
+                minTime = runTime
+
+            if runTime > maxTime:
+                maxTime = runTime
+
+        totalEnd = time.time()
+        totalTime = totalEnd - totalStart
+        meanTime = totalTime / its
+        print(f"Runtimes min, mean, max {(minTime*1000, meanTime*1000, maxTime*1000)}")
+        self.assertTrue(self.result, [totalTime, meanTime, minTime, maxTime])
 
     async def test_wait_2(self):
         macro = parse("wait(10,100).key(1)", self.context, DummyMapping, True)
         one_code = system_mapping.get("1")
 
-        await macro.run(self.handler)
-        self.assertListEqual(
-            self.result,
-            [(EV_KEY, one_code, 1), (EV_KEY, one_code, 0)],
-        )
-        self.assertEqual(len(macro.child_macros), 0)
+        minTime = 999999
+        maxTime = 0
+        its = 10
+        totalStart = time.time()
+        for loopcount in range(its):
+            runStart = time.time()
+            await macro.run(self.handler)
+            runEnd = time.time()
+            runTime = runEnd - runStart
+            if runTime < minTime:
+                minTime = runTime
+
+            if runTime > maxTime:
+                maxTime = runTime
+
+        totalEnd = time.time()
+        totalTime = totalEnd - totalStart
+        meanTime = totalTime / its
+        print(f"Runtimes min, mean, max {(minTime*1000, meanTime*1000, maxTime*1000)}")
+        self.assertTrue(self.result, [totalTime, meanTime, minTime, maxTime])
 
     async def test_wait_3(self):
         macro = parse("set(a,100).wait(10, $a).key(1)", self.context, DummyMapping, True)
         one_code = system_mapping.get("1")
 
-        await macro.run(self.handler)
-        self.assertListEqual(
-            self.result,
-            [(EV_KEY, one_code, 1), (EV_KEY, one_code, 0)],
-        )
-        self.assertEqual(len(macro.child_macros), 0)
+        minTime = 999999
+        maxTime = 0
+        its = 10
+        totalStart = time.time()
+        for loopcount in range(its):
+            runStart = time.time()
+            await macro.run(self.handler)
+            runEnd = time.time()
+            runTime = runEnd - runStart
+            if runTime < minTime:
+                minTime = runTime
+
+            if runTime > maxTime:
+                maxTime = runTime
+
+        totalEnd = time.time()
+        totalTime = totalEnd - totalStart
+        meanTime = totalTime / its
+        print(f"Runtimes min, mean, max {(minTime*1000, meanTime*1000, maxTime*1000)}")
+        self.assertTrue(self.result, [totalTime, meanTime, minTime, maxTime])
 
     async def test_duplicate_run(self):
         # it won't restart the macro, because that may screw up the

--- a/tests/unit/test_macros.py
+++ b/tests/unit/test_macros.py
@@ -915,6 +915,39 @@ class TestMacros(MacroTestBase):
         self.assertIsInstance(macro, Macro)
         self.assertListEqual(self.result, [])
 
+    async def test_wait_1(self):
+        macro = parse("wait(10).key(1)", self.context, DummyMapping, True)
+        one_code = system_mapping.get("1")
+
+        await macro.run(self.handler)
+        self.assertListEqual(
+            self.result,
+            [(EV_KEY, one_code, 1), (EV_KEY, one_code, 0)],
+        )
+        self.assertEqual(len(macro.child_macros), 0)
+
+    async def test_wait_2(self):
+        macro = parse("wait(10,100).key(1)", self.context, DummyMapping, True)
+        one_code = system_mapping.get("1")
+
+        await macro.run(self.handler)
+        self.assertListEqual(
+            self.result,
+            [(EV_KEY, one_code, 1), (EV_KEY, one_code, 0)],
+        )
+        self.assertEqual(len(macro.child_macros), 0)
+
+    async def test_wait_3(self):
+        macro = parse("set(a,100).wait(10, $a).key(1)", self.context, DummyMapping, True)
+        one_code = system_mapping.get("1")
+
+        await macro.run(self.handler)
+        self.assertListEqual(
+            self.result,
+            [(EV_KEY, one_code, 1), (EV_KEY, one_code, 0)],
+        )
+        self.assertEqual(len(macro.child_macros), 0)
+
     async def test_duplicate_run(self):
         # it won't restart the macro, because that may screw up the
         # internal state (in particular the _trigger_release_event).


### PR DESCRIPTION
Added an optional argument to wait to the amount of time wait can vary between between the 2 specific values. 2nd 'vary' argument is ignored if value is less than 1st 'time' argument. This more closely resembles parse.py's description of wait as having a range value and it's handy to have for automation obfuscation.