### PR TITLE
Improved logs and behavior when starting processes

### DIFF
--- a/DEBIAN/control
+++ b/DEBIAN/control
@@ -2,7 +2,7 @@ Package: input-remapper
 Version: 2.0.1
 Architecture: all
 Maintainer: Sezanzeb <proxima@sezanzeb.de>
-Depends: build-essential, libpython3-dev, libdbus-1-dev, python3, python3-setuptools, python3-evdev, python3-pydbus, python3-gi, gettext, python3-cairo, libgtk-3-0, libgtksourceview-4-dev, python3-pydantic, python3-packaging
+Depends: build-essential, libpython3-dev, libdbus-1-dev, python3, python3-setuptools, python3-evdev, python3-pydbus, python3-gi, gettext, python3-cairo, libgtk-3-0, libgtksourceview-4-dev, python3-pydantic, python3-packaging, python3-psutil
 Description: A tool to change the mapping of your input device buttons
 Replaces: python3-key-mapper, key-mapper
 Conflicts: python3-key-mapper, key-mapper

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ sudo systemctl enable --now input-remapper
 
 ##### Manual
 
-Dependencies: `python3-evdev` ≥1.3.0, `gtksourceview4`, `python3-devel`, `python3-pydantic`, `python3-pydbus`
+Dependencies: `python3-evdev` ≥1.3.0, `gtksourceview4`, `python3-devel`, `python3-pydantic`, `python3-pydbus`,
+`python3-psutil`
 
 Python packages need to be installed globally for the service to be able to import them. Don't use `--user`
 

--- a/bin/input-remapper-control
+++ b/bin/input-remapper-control
@@ -20,7 +20,7 @@
 
 """Control the dbus service from the command line."""
 
-from inputremapper.bin.input_remapper_control import main, parse_args
+from inputremapper.bin.input_remapper_control import InputRemapperControlBin
 
-if __name__ == '__main__':
-    main(parse_args())
+if __name__ == "__main__":
+    InputRemapperControlBin.main(InputRemapperControlBin.parse_args())

--- a/bin/input-remapper-gtk
+++ b/bin/input-remapper-gtk
@@ -20,7 +20,7 @@
 
 """Starts the user interface."""
 
-from inputremapper.bin.input_remapper_gtk import main
+from inputremapper.bin.input_remapper_gtk import InputRemapperGtkBin
 
-if __name__ == '__main__':
-    main()
+if __name__ == "__main__":
+    InputRemapperGtkBin.main()

--- a/bin/input-remapper-reader-service
+++ b/bin/input-remapper-reader-service
@@ -20,7 +20,9 @@
 
 """Starts the root reader-service."""
 
-from inputremapper.bin.input_remapper_reader_service import main
+from inputremapper.bin.input_remapper_reader_service import (
+    InputRemapperReaderServiceBin,
+)
 
-if __name__ == '__main__':
-    main()
+if __name__ == "__main__":
+    InputRemapperReaderServiceBin.main()

--- a/bin/input-remapper-service
+++ b/bin/input-remapper-service
@@ -20,7 +20,7 @@
 
 """Starts injecting keycodes based on the configuration."""
 
-from inputremapper.bin.input_remapper_service import main
+from inputremapper.bin.input_remapper_service import InputRemapperServiceBin
 
-if __name__ == '__main__':
-    main()
+if __name__ == "__main__":
+    InputRemapperServiceBin.main()

--- a/inputremapper/bin/input_remapper_gtk.py
+++ b/inputremapper/bin/input_remapper_gtk.py
@@ -63,6 +63,18 @@ def stop(daemon, controller):
     controller.close()
 
 
+def start_reader_service():
+    if ProcessUtils.count_python_processes("input-remapper-reader-service") >= 1:
+        logger.info("Found an input-remapper-reader-service to already be running")
+        return
+
+    try:
+        ReaderService.pkexec_reader_service()
+    except Exception as e:
+        logger.error(e)
+        sys.exit(11)
+
+
 def main() -> Tuple[
     UserInterface,
     Controller,
@@ -78,17 +90,6 @@ def main() -> Tuple[
         action="store_true",
         dest="debug",
         help=_("Displays additional debug information"),
-        default=False,
-    )
-    parser.add_argument(
-        "--without-reader-service",
-        action="store_true",
-        dest="without_reader_service",
-        help=_(
-            "Don't attempt to start input-remapper-reader-service automatically via "
-            "pkexec. You need to start it with elevated privileges yourself "
-            "afterwards, and restart it if it times out."
-        ),
         default=False,
     )
 
@@ -117,12 +118,7 @@ def main() -> Tuple[
             "This can cause problems while recording keys"
         )
 
-    if not options.without_reader_service:
-        try:
-            ReaderService.pkexec_reader_service()
-        except Exception as e:
-            logger.error(e)
-            sys.exit(11)
+    start_reader_service()
 
     daemon = Daemon.connect()
 

--- a/inputremapper/bin/input_remapper_gtk.py
+++ b/inputremapper/bin/input_remapper_gtk.py
@@ -29,6 +29,8 @@ from typing import Tuple
 
 import gi
 
+from inputremapper.bin.process_utils import ProcessUtils
+
 gi.require_version("Gtk", "3.0")
 gi.require_version("GLib", "2.0")
 gi.require_version("GtkSource", "4")
@@ -108,6 +110,12 @@ def main() -> Tuple[
     # privileged service creates and owns those pipes, and then they cannot be accessed
     # by the user.
     reader_client = ReaderClient(message_broker, _Groups())
+
+    if ProcessUtils.count_python_processes("input-remapper-gtk") >= 2:
+        logger.warning(
+            "Another input-remapper GUI is already running. "
+            "This can cause problems while recording keys"
+        )
 
     if not options.without_reader_service:
         try:

--- a/inputremapper/bin/input_remapper_gtk.py
+++ b/inputremapper/bin/input_remapper_gtk.py
@@ -57,26 +57,6 @@ from inputremapper.configs.migrations import Migrations
 
 class InputRemapperGtkBin:
     @staticmethod
-    def stop(daemon, controller):
-        if isinstance(daemon, Daemon):
-            # have fun debugging completely unrelated tests if you remove this
-            daemon.stop_all()
-
-        controller.close()
-
-    @staticmethod
-    def start_reader_service():
-        if ProcessUtils.count_python_processes("input-remapper-reader-service") >= 1:
-            logger.info("Found an input-remapper-reader-service to already be running")
-            return
-
-        try:
-            ReaderService.pkexec_reader_service()
-        except Exception as e:
-            logger.error(e)
-            sys.exit(11)
-
-    @staticmethod
     def main() -> Tuple[
         UserInterface,
         Controller,
@@ -151,3 +131,23 @@ class InputRemapperGtkBin:
             daemon,
             global_config,
         )
+
+    @staticmethod
+    def start_reader_service():
+        if ProcessUtils.count_python_processes("input-remapper-reader-service") >= 1:
+            logger.info("Found an input-remapper-reader-service to already be running")
+            return
+
+        try:
+            ReaderService.pkexec_reader_service()
+        except Exception as e:
+            logger.error(e)
+            sys.exit(11)
+
+    @staticmethod
+    def stop(daemon, controller):
+        if isinstance(daemon, Daemon):
+            # have fun debugging completely unrelated tests if you remove this
+            daemon.stop_all()
+
+        controller.close()

--- a/inputremapper/bin/input_remapper_reader_service.py
+++ b/inputremapper/bin/input_remapper_reader_service.py
@@ -18,8 +18,8 @@
 # You should have received a copy of the GNU General Public License
 # along with input-remapper.  If not, see <https://www.gnu.org/licenses/>.
 
-
 """Starts the root reader-service."""
+
 import asyncio
 import atexit
 import os
@@ -59,9 +59,11 @@ def main() -> None:
     if os.getuid() != 0:
         logger.warning("The reader-service usually needs elevated privileges")
 
-    while not ReaderService.pipes_exist():
-        time.sleep(1)
-        logger.debug("Waiting for pipes to be created")
+    if not ReaderService.pipes_exist():
+        logger.info("Waiting for pipes to be created by the GUI")
+        while not ReaderService.pipes_exist():
+            time.sleep(0.5)
+            logger.debug("Waiting...")
 
     def on_exit():
         """Don't remain idle and alive when the GUI exits via ctrl+c."""

--- a/inputremapper/bin/input_remapper_reader_service.py
+++ b/inputremapper/bin/input_remapper_reader_service.py
@@ -59,10 +59,9 @@ def main() -> None:
     if os.getuid() != 0:
         logger.warning("The reader-service usually needs elevated privileges")
 
-    if not ReaderService.pipes_exist():
-        while not ReaderService.pipes_exist():
-            time.sleep(1)
-            logger.debug("Waiting for pipes to be created")
+    while not ReaderService.pipes_exist():
+        time.sleep(1)
+        logger.debug("Waiting for pipes to be created")
 
     def on_exit():
         """Don't remain idle and alive when the GUI exits via ctrl+c."""

--- a/inputremapper/bin/input_remapper_service.py
+++ b/inputremapper/bin/input_remapper_service.py
@@ -31,38 +31,40 @@ from inputremapper.injection.mapping_handlers.mapping_parser import MappingParse
 from inputremapper.logging.logger import logger
 
 
-def main() -> None:
-    parser = ArgumentParser()
-    parser.add_argument(
-        "-d",
-        "--debug",
-        action="store_true",
-        dest="debug",
-        help="Displays additional debug information",
-        default=False,
-    )
-    parser.add_argument(
-        "--hide-info",
-        action="store_true",
-        dest="hide_info",
-        help="Don't display version information",
-        default=False,
-    )
+class InputRemapperServiceBin:
+    @staticmethod
+    def main() -> None:
+        parser = ArgumentParser()
+        parser.add_argument(
+            "-d",
+            "--debug",
+            action="store_true",
+            dest="debug",
+            help="Displays additional debug information",
+            default=False,
+        )
+        parser.add_argument(
+            "--hide-info",
+            action="store_true",
+            dest="hide_info",
+            help="Don't display version information",
+            default=False,
+        )
 
-    options = parser.parse_args(sys.argv[1:])
+        options = parser.parse_args(sys.argv[1:])
 
-    logger.update_verbosity(options.debug)
+        logger.update_verbosity(options.debug)
 
-    # import input-remapper stuff after setting the log verbosity
-    from inputremapper.daemon import Daemon
+        # import input-remapper stuff after setting the log verbosity
+        from inputremapper.daemon import Daemon
 
-    if not options.hide_info:
-        logger.log_info("input-remapper-service")
+        if not options.hide_info:
+            logger.log_info("input-remapper-service")
 
-    global_config = GlobalConfig()
-    global_uinputs = GlobalUInputs(UInput)
-    mapping_parser = MappingParser(global_uinputs)
+        global_config = GlobalConfig()
+        global_uinputs = GlobalUInputs(UInput)
+        mapping_parser = MappingParser(global_uinputs)
 
-    daemon = Daemon(global_config, global_uinputs, mapping_parser)
-    daemon.publish()
-    daemon.run()
+        daemon = Daemon(global_config, global_uinputs, mapping_parser)
+        daemon.publish()
+        daemon.run()

--- a/inputremapper/bin/process_utils.py
+++ b/inputremapper/bin/process_utils.py
@@ -1,0 +1,20 @@
+import psutil
+
+
+class ProcessUtils:
+    @staticmethod
+    def count_python_processes(name: str) -> int:
+        # This is somewhat complicated, because there might also be a "sudo <name>"
+        # process.
+        count = 0
+        pids = psutil.pids()
+        for pid in pids:
+            try:
+                process = psutil.Process(pid)
+                cmdline = process.cmdline()
+                if len(cmdline) >= 2 and "python" in cmdline[0] and name in cmdline[1]:
+                    count += 1
+            except Exception:
+                pass
+
+        return count

--- a/inputremapper/gui/reader_client.py
+++ b/inputremapper/gui/reader_client.py
@@ -45,7 +45,6 @@ from inputremapper.gui.reader_service import (
     CMD_TERMINATE,
     CMD_REFRESH_GROUPS,
     CMD_STOP_READING,
-    get_pipe_paths,
     ReaderService,
 )
 from inputremapper.gui.utils import CTX_ERROR
@@ -120,8 +119,8 @@ class ReaderClient:
 
     def connect(self):
         """Connect to the reader-service."""
-        results_pipe = Pipe(get_pipe_paths()[0])
-        commands_pipe = Pipe(get_pipe_paths()[1])
+        results_pipe = Pipe(ReaderService.get_pipe_paths()[0])
+        commands_pipe = Pipe(ReaderService.get_pipe_paths()[1])
         return results_pipe, commands_pipe
 
     def attach_to_events(self):

--- a/inputremapper/injection/macros/macro.py
+++ b/inputremapper/injection/macros/macro.py
@@ -156,20 +156,6 @@ class Macro:
         """Check if the macro is waiting for a key to be released."""
         return not self._trigger_release_event.is_set()
 
-    def get_capabilities(self):
-        """Get the merged capabilities of the macro and its children."""
-        capabilities = copy.deepcopy(self.capabilities)
-
-        for macro in self.child_macros:
-            macro_capabilities = macro.get_capabilities()
-            for type_ in macro_capabilities:
-                if type_ not in capabilities:
-                    capabilities[type_] = set()
-
-                capabilities[type_].update(macro_capabilities[type_])
-
-        return capabilities
-
     async def run(self, handler: Callable):
         """Run the macro.
 

--- a/tests/integration/test_gui.py
+++ b/tests/integration/test_gui.py
@@ -85,7 +85,7 @@ from inputremapper.gui.user_interface import UserInterface
 from inputremapper.injection.injector import InjectorState
 from inputremapper.configs.input_config import InputCombination, InputConfig
 from inputremapper.daemon import Daemon, DaemonProxy
-from inputremapper.bin.input_remapper_gtk import stop, main
+from inputremapper.bin.input_remapper_gtk import InputRemapperGtkBin
 
 from tests.lib.test_setup import test_setup
 
@@ -108,11 +108,11 @@ def launch() -> Tuple[
     GlobalConfig,
 ]:
     """Start input-remapper-gtk."""
-    return_ = main()
+    return_ = InputRemapperGtkBin.main()
     gtk_iteration()
     # otherwise a new handler is added with each call to launch, which
     # spams tons of garbage when all tests finish
-    atexit.unregister(stop)
+    atexit.unregister(InputRemapperGtkBin.stop)
     return return_
 
 

--- a/tests/unit/test_control.py
+++ b/tests/unit/test_control.py
@@ -26,7 +26,7 @@ import time
 import unittest
 from unittest.mock import patch
 
-from inputremapper.bin.input_remapper_control import InputRemapperControl
+from inputremapper.bin.input_remapper_control import InputRemapperControlBin
 from inputremapper.configs.global_config import GlobalConfig
 from inputremapper.configs.migrations import Migrations
 from inputremapper.configs.paths import PathUtils
@@ -52,7 +52,7 @@ class TestControl(unittest.TestCase):
         self.global_uinputs = GlobalUInputs(FrontendUInput)
         self.migrations = Migrations(self.global_uinputs)
         self.mapping_parser = MappingParser(self.global_uinputs)
-        self.input_remapper_control = InputRemapperControl(
+        self.input_remapper_control = InputRemapperControlBin(
             self.global_config, self.migrations
         )
 


### PR DESCRIPTION
- input-remapper-reader-service waits for pipes to be created by the gui, making it possible to start the input-remapper-reader-service process first, and then the gui. If it is already running, the gui will not use pkexec to ask for a password, making it behave similar to the startup of input-remapper-service. This means https://github.com/sezanzeb/input-remapper/pull/980 is no longer necessary and can be reverted
- checks if another reader-service is already running and logs a warning
- gui checks if another gui is already running and logs a warning
- wraps code in inputremapper/bin in classes, which makes writing patches in tests easier
