### PR TITLE
Add mod_tap macro

### DIFF
--- a/inputremapper/injection/macros/parse.py
+++ b/inputremapper/injection/macros/parse.py
@@ -60,6 +60,7 @@ TASK_FACTORIES = {
     "set": Macro.add_set,
     "if_tap": Macro.add_if_tap,
     "if_single": Macro.add_if_single,
+    "mod_tap": Macro.add_mod_tap,
     "add": Macro.add_add,
     # Those are only kept for backwards compatibility with old macros. The space for
     # writing macro was very constrained in the past, so shorthands were introduced:


### PR DESCRIPTION
Adds a convenient macro for https://github.com/sezanzeb/input-remapper/issues/996

Name matches how other tools call it, like https://docs.qmk.fm/mod_tap

This differs from the second example of _Nested tap_ in https://github.com/qmk/qmk_firmware/blob/78a0adfbb4d2c4e12f93f2a62ded0020d406243e/docs/tap_hold.md#nested-tap-abba-nested-tap. There, it would write `ab` instead of `B`. Because I don't think there is any easy way to suppress an event that is not used as an input for something in input-remapper (b in this case). When it is seen by the mod_tap macro, the mod_tap macro has to decide what to do, right now, and it will have to inject its default key.

A `mode` parameter could be introduced later, which could accept something like `"QMK_DEFAULT"` or `"PERMISSIVE_HOLD"` and stuff.

Or, we could already maybe make `event` carry a `event.dont_forward` flag, that prevents it from being forwarded. In that case, the mod_tap macro has to inject all the events that arrived while the modifier was held down when it is released.

TODO:
- [ ] macros.md
- [ ] mention home-row-modifiers in examples.md
- [ ] tests based on the "default" column in https://github.com/qmk/qmk_firmware/blob/78a0adfbb4d2c4e12f93f2a62ded0020d406243e/docs/tap_hold.md#comparison-comparison
- [ ] https://zmk.dev/docs/keymaps/behaviors/mod-tap uses 200ms