### PR TITLE
Improved error status messages

### DIFF
--- a/data/input-remapper.glade
+++ b/data/input-remapper.glade
@@ -1798,7 +1798,7 @@ Macros allow multiple characters to be written with a single key-press. Informat
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="tooltip-text" translatable="yes">Map this input to an Analog Axis</property>
+                <property name="tooltip-text" translatable="yes">Map this input to an Analog Axis. Only possible for analog inputs and mice.</property>
                 <property name="opacity">0.5</property>
                 <property name="margin-start">18</property>
                 <property name="hexpand">True</property>

--- a/inputremapper/configs/mapping.py
+++ b/inputremapper/configs/mapping.py
@@ -71,7 +71,7 @@ from inputremapper.configs.validation_errors import (
     OutputSymbolVariantError,
     MacroButTypeOrCodeSetError,
     SymbolAndCodeMismatchError,
-    MissingMacroOrKeyError,
+    WrongOutputTypeForButtonError,
     MissingOutputAxisError,
 )
 from inputremapper.gui.gettext import _
@@ -470,7 +470,7 @@ class Mapping(UIMapping):
         output_symbol = values.get("output_symbol")
 
         if not use_as_analog and not output_symbol and output_type != EV_KEY:
-            raise MissingMacroOrKeyError()
+            raise WrongOutputTypeForButtonError()
 
         if (
             use_as_analog

--- a/inputremapper/configs/mapping.py
+++ b/inputremapper/configs/mapping.py
@@ -71,8 +71,9 @@ from inputremapper.configs.validation_errors import (
     OutputSymbolVariantError,
     MacroButTypeOrCodeSetError,
     SymbolAndCodeMismatchError,
-    WrongOutputTypeForButtonError,
+    WrongOutputTypeForKeyError,
     MissingOutputAxisError,
+    MissingMacroOrKeyError,
 )
 from inputremapper.gui.gettext import _
 from inputremapper.gui.messages.message_types import MessageType
@@ -323,10 +324,10 @@ class UIMapping(BaseModel):
         output_symbol = values.get("output_symbol")
 
         if output_type is not None and output_code is not None and not output_symbol:
-            values["mapping_type"] = "analog"
+            values["mapping_type"] = MappingType.ANALOG.value
 
         if output_type is None and output_code is None and output_symbol:
-            values["mapping_type"] = "key_macro"
+            values["mapping_type"] = MappingType.KEY_MACRO.value
 
         return values
 
@@ -467,10 +468,14 @@ class Mapping(UIMapping):
         use_as_analog = analog_input_config is not None
 
         output_type = values.get("output_type")
+        mapping_type = values.get("mapping_type")
         output_symbol = values.get("output_symbol")
 
-        if not use_as_analog and not output_symbol and output_type != EV_KEY:
-            raise WrongOutputTypeForButtonError()
+        if not use_as_analog and not mapping_type == MappingType.KEY_MACRO.value:
+            raise WrongOutputTypeForKeyError()
+
+        if not use_as_analog and not output_symbol:
+            raise MissingMacroOrKeyError()
 
         if (
             use_as_analog

--- a/inputremapper/configs/mapping.py
+++ b/inputremapper/configs/mapping.py
@@ -34,6 +34,8 @@ from evdev.ecodes import (
 )
 from packaging import version
 
+from inputremapper.logging.logger import logger
+
 try:
     from pydantic.v1 import (
         BaseModel,
@@ -71,7 +73,7 @@ from inputremapper.configs.validation_errors import (
     OutputSymbolVariantError,
     MacroButTypeOrCodeSetError,
     SymbolAndCodeMismatchError,
-    WrongOutputTypeForKeyError,
+    WrongMappingTypeForKeyError,
     MissingOutputAxisError,
     MissingMacroOrKeyError,
 )
@@ -153,7 +155,9 @@ class UIMapping(BaseModel):
     target_uinput: Optional[Union[str, KnownUinput]] = None
 
     # Either `output_symbol` or `output_type` and `output_code` is required
+    # Only set if output is "Key or Macro":
     output_symbol: Optional[str] = None  # The symbol or macro string if applicable
+    # "Analog Axis" or if preset edited manually to inject a code instead of a symbol:
     output_type: Optional[int] = None  # The event type of the mapped event
     output_code: Optional[int] = None  # The event code of the mapped event
 
@@ -323,10 +327,19 @@ class UIMapping(BaseModel):
         output_code = values.get("output_code")
         output_symbol = values.get("output_symbol")
 
-        if output_type is not None and output_code is not None and not output_symbol:
+        if output_type is not None and output_symbol is not None:
+            # This is currently only possible when someone edits the preset file by
+            # hand. A key-output mapping without an output_symbol, but type and code
+            # instead, is valid as well.
+            logger.debug("Both output_type and output_symbol are set")
+
+        if output_type != EV_KEY and output_code is not None and not output_symbol:
             values["mapping_type"] = MappingType.ANALOG.value
 
         if output_type is None and output_code is None and output_symbol:
+            values["mapping_type"] = MappingType.KEY_MACRO.value
+
+        if output_type == EV_KEY:
             values["mapping_type"] = MappingType.KEY_MACRO.value
 
         return values
@@ -464,21 +477,23 @@ class Mapping(UIMapping):
         And vice versa."""
         assert isinstance(values.get("input_combination"), InputCombination)
         combination: InputCombination = values["input_combination"]
-        analog_input_config = combination.find_analog_input_config()
-        use_as_analog = analog_input_config is not None
 
+        analog_input_config = combination.find_analog_input_config()
+        defines_analog_input = analog_input_config is not None
         output_type = values.get("output_type")
+        output_code = values.get("output_code")
         mapping_type = values.get("mapping_type")
         output_symbol = values.get("output_symbol")
+        output_key_set = output_symbol or (output_type == EV_KEY and output_code)
 
-        if not use_as_analog and not mapping_type == MappingType.KEY_MACRO.value:
-            raise WrongOutputTypeForKeyError()
+        if not defines_analog_input and mapping_type != MappingType.KEY_MACRO.value:
+            raise WrongMappingTypeForKeyError()
 
-        if not use_as_analog and not output_symbol:
+        if not defines_analog_input and not output_key_set:
             raise MissingMacroOrKeyError()
 
         if (
-            use_as_analog
+            defines_analog_input
             and output_type not in (EV_ABS, EV_REL)
             and output_symbol != DISABLE_NAME
         ):

--- a/inputremapper/configs/mapping.py
+++ b/inputremapper/configs/mapping.py
@@ -486,6 +486,10 @@ class Mapping(UIMapping):
         output_symbol = values.get("output_symbol")
         output_key_set = output_symbol or (output_type == EV_KEY and output_code)
 
+        if mapping_type is None:
+            # Empty mapping most likely
+            return values
+
         if not defines_analog_input and mapping_type != MappingType.KEY_MACRO.value:
             raise WrongMappingTypeForKeyError()
 

--- a/inputremapper/configs/validation_errors.py
+++ b/inputremapper/configs/validation_errors.py
@@ -97,9 +97,9 @@ class SymbolAndCodeMismatchError(ValueError):
         )
 
 
-class WrongOutputTypeForKeyError(ValueError):
+class WrongMappingTypeForKeyError(ValueError):
     def __init__(self):
-        super().__init__(f"Wrong output_type for key input")
+        super().__init__(f"Wrong mapping_type for key input")
 
 
 class MissingMacroOrKeyError(ValueError):

--- a/inputremapper/configs/validation_errors.py
+++ b/inputremapper/configs/validation_errors.py
@@ -97,9 +97,14 @@ class SymbolAndCodeMismatchError(ValueError):
         )
 
 
-class WrongOutputTypeForButtonError(ValueError):
+class WrongOutputTypeForKeyError(ValueError):
     def __init__(self):
-        super().__init__("missing macro or key")
+        super().__init__(f"Wrong output_type for key input")
+
+
+class MissingMacroOrKeyError(ValueError):
+    def __init__(self):
+        super().__init__("Missing macro or key")
 
 
 class MissingOutputAxisError(ValueError):

--- a/inputremapper/configs/validation_errors.py
+++ b/inputremapper/configs/validation_errors.py
@@ -97,7 +97,7 @@ class SymbolAndCodeMismatchError(ValueError):
         )
 
 
-class MissingMacroOrKeyError(ValueError):
+class WrongOutputTypeForButtonError(ValueError):
     def __init__(self):
         super().__init__("missing macro or key")
 

--- a/inputremapper/gui/components/editor.py
+++ b/inputremapper/gui/components/editor.py
@@ -37,12 +37,13 @@ from evdev.ecodes import (
     BTN_EXTRA,
     BTN_SIDE,
 )
-
 from gi.repository import Gtk, GtkSource, Gdk
 
-from inputremapper.configs.mapping import MappingData
 from inputremapper.configs.input_config import InputCombination, InputConfig
+from inputremapper.configs.keyboard_layout import keyboard_layout, XKB_KEYCODE_OFFSET
+from inputremapper.configs.mapping import MappingData
 from inputremapper.groups import DeviceType
+from inputremapper.gui.components.output_type_names import OutputTypeNames
 from inputremapper.gui.controller import Controller
 from inputremapper.gui.gettext import _
 from inputremapper.gui.messages.message_broker import (
@@ -57,7 +58,6 @@ from inputremapper.gui.messages.message_data import (
 from inputremapper.gui.utils import HandlerDisabled, Colors
 from inputremapper.injection.mapping_handlers.axis_transform import Transformation
 from inputremapper.input_event import InputEvent
-from inputremapper.configs.keyboard_layout import keyboard_layout, XKB_KEYCODE_OFFSET
 from inputremapper.utils import get_evdev_constant_name
 
 Capabilities = Dict[int, List]
@@ -1038,11 +1038,11 @@ class KeyAxisStackSwitcher:
 
     def _set_active(self, mapping_type: Literal["key_macro", "analog"]):
         if mapping_type == "analog":
-            self._stack.set_visible_child_name("Analog Axis")
+            self._stack.set_visible_child_name(OutputTypeNames.analog_axis)
             active = self._analog_toggle
             inactive = self._key_macro_toggle
         else:
-            self._stack.set_visible_child_name("Key or Macro")
+            self._stack.set_visible_child_name(OutputTypeNames.key_or_macro)
             active = self._key_macro_toggle
             inactive = self._analog_toggle
 

--- a/inputremapper/gui/components/editor.py
+++ b/inputremapper/gui/components/editor.py
@@ -41,7 +41,7 @@ from gi.repository import Gtk, GtkSource, Gdk
 
 from inputremapper.configs.input_config import InputCombination, InputConfig
 from inputremapper.configs.keyboard_layout import keyboard_layout, XKB_KEYCODE_OFFSET
-from inputremapper.configs.mapping import MappingData
+from inputremapper.configs.mapping import MappingData, MappingType
 from inputremapper.groups import DeviceType
 from inputremapper.gui.components.output_type_names import OutputTypeNames
 from inputremapper.gui.controller import Controller
@@ -1037,7 +1037,7 @@ class KeyAxisStackSwitcher:
         self._message_broker.subscribe(MessageType.mapping, self._on_mapping_message)
 
     def _set_active(self, mapping_type: Literal["key_macro", "analog"]):
-        if mapping_type == "analog":
+        if mapping_type == MappingType.ANALOG.value:
             self._stack.set_visible_child_name(OutputTypeNames.analog_axis)
             active = self._analog_toggle
             inactive = self._key_macro_toggle
@@ -1053,11 +1053,11 @@ class KeyAxisStackSwitcher:
 
     def _on_mapping_message(self, mapping: MappingData):
         # fist check the actual mapping
-        if mapping.mapping_type == "analog":
-            self._set_active("analog")
+        if mapping.mapping_type == MappingType.ANALOG.value:
+            self._set_active(MappingType.ANALOG.value)
 
-        if mapping.mapping_type == "key_macro":
-            self._set_active("key_macro")
+        if mapping.mapping_type == MappingType.KEY_MACRO.value:
+            self._set_active(MappingType.KEY_MACRO.value)
 
     def _on_gtk_toggle(self, btn: Gtk.ToggleButton):
         # get_active returns the new toggle state already
@@ -1070,9 +1070,9 @@ class KeyAxisStackSwitcher:
             return
 
         if btn is self._key_macro_toggle:
-            self._controller.update_mapping(mapping_type="key_macro")
+            self._controller.update_mapping(mapping_type=MappingType.KEY_MACRO.value)
         else:
-            self._controller.update_mapping(mapping_type="analog")
+            self._controller.update_mapping(mapping_type=MappingType.ANALOG.value)
 
 
 class TransformationDrawArea:

--- a/inputremapper/gui/components/output_type_names.py
+++ b/inputremapper/gui/components/output_type_names.py
@@ -1,0 +1,3 @@
+class OutputTypeNames:
+    analog_axis = "Analog Axis"
+    key_or_macro = "Key or Macro"

--- a/inputremapper/gui/controller.py
+++ b/inputremapper/gui/controller.py
@@ -242,7 +242,7 @@ class Controller:
 
         if pydantify(WrongMappingTypeForKeyError) in error_type:
             error_message = _(
-                "The input specifies a button, but the output type is not "
+                "The input specifies a key, but the output type is not "
                 f'"{OutputTypeNames.key_or_macro}".'
             )
 

--- a/inputremapper/gui/controller.py
+++ b/inputremapper/gui/controller.py
@@ -683,6 +683,7 @@ class Controller:
         state = msg.state
 
         def running() -> None:
+            assert self.data_manager.active_preset is not None
             msg = _('Applied preset "%s"') % self.data_manager.active_preset.name
             if self.data_manager.active_preset.dangerously_mapped_btn_left():
                 msg += _(", CTRL + DEL to stop")
@@ -692,6 +693,7 @@ class Controller:
             )
 
         def no_grab() -> None:
+            assert self.data_manager.active_preset is not None
             msg = (
                 _('Failed to apply preset "%s"') % self.data_manager.active_preset.name
             )

--- a/inputremapper/gui/controller.py
+++ b/inputremapper/gui/controller.py
@@ -41,15 +41,18 @@ from inputremapper.configs.input_config import InputCombination, InputConfig
 from inputremapper.configs.mapping import (
     MappingData,
     UIMapping,
+    MappingType,
+)
+from inputremapper.configs.paths import PathUtils
+from inputremapper.configs.validation_errors import (
+    pydantify,
+    MissingMacroOrKeyError,
     MacroButTypeOrCodeSetError,
     SymbolAndCodeMismatchError,
     MissingOutputAxisError,
     WrongMappingTypeForKeyError,
     OutputSymbolVariantError,
-    MappingType,
 )
-from inputremapper.configs.paths import PathUtils
-from inputremapper.configs.validation_errors import pydantify
 from inputremapper.exceptions import DataManagementError
 from inputremapper.gui.components.output_type_names import OutputTypeNames
 from inputremapper.gui.data_manager import DataManager, DEFAULT_PRESET_NAME
@@ -263,6 +266,9 @@ class Controller:
                 )
 
             return error_message
+
+        if pydantify(MissingMacroOrKeyError) in error_type:
+            return _("Missing macro or key")
 
         return error_message
 

--- a/inputremapper/gui/controller.py
+++ b/inputremapper/gui/controller.py
@@ -658,7 +658,7 @@ class Controller:
             self.message_broker.unsubscribe(self.show_injector_result)
             self.show_status(
                 CTX_APPLY,
-                _("Failed to apply preset %s") % self.data_manager.active_preset.name,
+                _('Failed to apply preset "%s"') % self.data_manager.active_preset.name,
             )
 
     def show_injector_result(self, msg: InjectorStateMessage):
@@ -667,7 +667,7 @@ class Controller:
         state = msg.state
 
         def running():
-            msg = _("Applied preset %s") % self.data_manager.active_preset.name
+            msg = _('Applied preset "%s"') % self.data_manager.active_preset.name
             if self.data_manager.active_preset.dangerously_mapped_btn_left():
                 msg += _(", CTRL + DEL to stop")
             self.show_status(CTX_APPLY, msg)
@@ -697,10 +697,10 @@ class Controller:
         assert self.data_manager.active_preset  # make mypy happy
         state_calls: Dict[InjectorState, Callable] = {
             InjectorState.RUNNING: running,
-            InjectorState.FAILED: partial(
+            InjectorState.ERROR: partial(
                 self.show_status,
                 CTX_ERROR,
-                _('Failed to apply preset "%s"') % self.data_manager.active_preset.name,
+                _('Error applying preset "%s"') % self.data_manager.active_preset.name,
             ),
             InjectorState.NO_GRAB: no_grab,
             InjectorState.UPGRADE_EVDEV: partial(

--- a/inputremapper/gui/controller.py
+++ b/inputremapper/gui/controller.py
@@ -44,7 +44,7 @@ from inputremapper.configs.mapping import (
     MacroButTypeOrCodeSetError,
     SymbolAndCodeMismatchError,
     MissingOutputAxisError,
-    WrongOutputTypeForKeyError,
+    WrongMappingTypeForKeyError,
     OutputSymbolVariantError,
     MappingType,
 )
@@ -240,7 +240,7 @@ class Controller:
                 )
             return error_message
 
-        if pydantify(WrongOutputTypeForKeyError) in error_type:
+        if pydantify(WrongMappingTypeForKeyError) in error_type:
             error_message = _(
                 "The input specifies a button, but the output type is not "
                 f'"{OutputTypeNames.key_or_macro}".'

--- a/inputremapper/gui/data_manager.py
+++ b/inputremapper/gui/data_manager.py
@@ -570,7 +570,7 @@ class DataManager:
             self.do_when_injector_state(
                 {
                     InjectorState.RUNNING,
-                    InjectorState.FAILED,
+                    InjectorState.ERROR,
                     InjectorState.NO_GRAB,
                     InjectorState.UPGRADE_EVDEV,
                 },

--- a/inputremapper/injection/injector.py
+++ b/inputremapper/injection/injector.py
@@ -409,8 +409,8 @@ class Injector(multiprocessing.Process):
 
         self._devices = self.group.get_devices()
 
-        # InputConfigs may not contain the origin_hash information, this will try to make a
-        # good guess if the origin_hash information is missing or invalid.
+        # InputConfigs may not contain the origin_hash information, this will try to
+        # make a good guess if the origin_hash information is missing or invalid.
         self._update_preset()
 
         # grab devices as early as possible. If events appear that won't get

--- a/inputremapper/injection/injector.py
+++ b/inputremapper/injection/injector.py
@@ -62,7 +62,7 @@ class InjectorCommand(str, enum.Enum):
 class InjectorState(str, enum.Enum):
     UNKNOWN = "UNKNOWN"
     STARTING = "STARTING"
-    FAILED = "FAILED"
+    ERROR = "FAILED"
     RUNNING = "RUNNING"
     STOPPED = "STOPPED"
     NO_GRAB = "NO_GRAB"
@@ -174,7 +174,7 @@ class Injector(multiprocessing.Process):
             if state in (InjectorState.STARTING, InjectorState.RUNNING) and not alive:
                 # we thought it is running (maybe it was when get_state was previously),
                 # but the process is not alive. It probably crashed
-                state = InjectorState.FAILED
+                state = InjectorState.ERROR
                 logger.error("Injector was unexpectedly found stopped")
 
         logger.debug(

--- a/tests/integration/test_components.py
+++ b/tests/integration/test_components.py
@@ -905,11 +905,12 @@ class TestCodeEditor(ComponentBaseTest):
 
         def focus():
             self.gui.grab_focus()
-            gtk_iteration(5)
+            # Do as many iterations as needed to make it work.
+            gtk_iteration(15)
 
         def unfocus():
             window.set_focus(None)
-            gtk_iteration(5)
+            gtk_iteration(15)
 
         # clears the input when we enter the editor widget
         focus()

--- a/tests/unit/test_controller.py
+++ b/tests/unit/test_controller.py
@@ -50,7 +50,7 @@ from inputremapper.gui.messages.message_data import (
 from inputremapper.gui.reader_client import ReaderClient
 from inputremapper.gui.utils import CTX_ERROR, CTX_APPLY, gtk_iteration
 from inputremapper.gui.gettext import _
-from inputremapper.injection.global_uinputs import GlobalUInputs, UInput, FrontendUInput
+from inputremapper.injection.global_uinputs import GlobalUInputs, FrontendUInput
 from inputremapper.configs.mapping import UIMapping, MappingData, Mapping
 from tests.lib.spy import spy
 from tests.lib.patches import FakeDaemonProxy
@@ -1048,17 +1048,17 @@ class TestController(unittest.TestCase):
 
         self.controller.start_injecting()
         gtk_iteration(50)
-        self.assertEqual(calls[-1].msg, _("Applied preset %s") % "preset2")
+        self.assertEqual(calls[-1].msg, _('Applied preset "%s"') % "preset2")
 
-        mock.return_value = InjectorState.FAILED
+        mock.return_value = InjectorState.ERROR
         self.controller.start_injecting()
         gtk_iteration(50)
-        self.assertEqual(calls[-1].msg, _("Failed to apply preset %s") % "preset2")
+        self.assertEqual(calls[-1].msg, _('Error applying preset "%s"') % "preset2")
 
         mock.return_value = InjectorState.NO_GRAB
         self.controller.start_injecting()
         gtk_iteration(50)
-        self.assertEqual(calls[-1].msg, "The device was not grabbed")
+        self.assertEqual(calls[-1].msg, _('Failed to apply preset "%s"') % "preset2")
 
         mock.return_value = InjectorState.UPGRADE_EVDEV
         self.controller.start_injecting()

--- a/tests/unit/test_controller.py
+++ b/tests/unit/test_controller.py
@@ -999,7 +999,7 @@ class TestController(unittest.TestCase):
             calls[-1],
             StatusData(
                 CTX_APPLY,
-                _("Failed to apply preset %s") % self.data_manager.active_preset.name,
+                _('Failed to apply preset "%s"') % self.data_manager.active_preset.name,
             ),
         )
 

--- a/tests/unit/test_injector.py
+++ b/tests/unit/test_injector.py
@@ -107,7 +107,7 @@ class TestInjector(unittest.IsolatedAsyncioTestCase):
             time.sleep(0.2)
             self.assertIn(
                 self.injector.get_state(),
-                (InjectorState.STOPPED, InjectorState.FAILED, InjectorState.NO_GRAB),
+                (InjectorState.STOPPED, InjectorState.ERROR, InjectorState.NO_GRAB),
             )
             self.injector = None
         evdev.InputDevice.grab = self.grab


### PR DESCRIPTION
https://github.com/sezanzeb/input-remapper/issues/1022 

- The error message when applying a preset failed was hiding the validation error previously.
- When the output type is incorrect for keys, it shows a better error message now.
- Switching to a different mapping within a preset shows the error of that mapping. Instead of always showing the error of the last mapping in the list.