### PR TITLE
Install dbus policy in /usr/share

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ setup(
         ("/usr/share/icons/hicolor/scalable/apps/", ["data/input-remapper.svg"]),
         ("/usr/share/polkit-1/actions/", ["data/input-remapper.policy"]),
         ("/usr/lib/systemd/system", ["data/input-remapper.service"]),
-        ("/etc/dbus-1/system.d/", ["data/inputremapper.Control.conf"]),
+        ("/usr/share/dbus-1/system.d/", ["data/inputremapper.Control.conf"]),
         ("/etc/xdg/autostart/", ["data/input-remapper-autoload.desktop"]),
         ("/usr/lib/udev/rules.d", ["data/99-input-remapper.rules"]),
         ("/usr/bin/", ["bin/input-remapper-gtk"]),


### PR DESCRIPTION
Since dbus 1.14.0, installing dbus policies in /etc is deprecated; see the deprecations section in the release announcement, https://lists.freedesktop.org/archives/dbus/2022-February/018131.html

dbus supports policies in /usr/share since 1.10, released in August 2015, so this should be safe.