### PR TITLE
Add install steps for Gentoo

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,17 @@ sudo systemctl enable --now input-remapper
 
 <br/>
 
+### Gentoo
+
+`games-util/input-remapper` is available in [Project:GURU](https://wiki.gentoo.org/wiki/Project:GURU/Information_for_End_Users).
+
+```bash
+sudo emerge -av games-util/input-remapper
+sudo systemctl enable --now input-remapper
+```
+
+<br/>
+
 ### Other Distros
 
 Figure out the packages providing those dependencies in your distro, and install them:


### PR DESCRIPTION
https://github.com/gentoo/guru/tree/master/games-util/input-remapper

Package is now available in the Gentoo User Repository (GURU). I am the package maintainer.