### PR TITLE
Fix the .desktop reference in metainfo

### DIFF
--- a/data/io.github.sezanzeb.input_remapper.metainfo.xml
+++ b/data/io.github.sezanzeb.input_remapper.metainfo.xml
@@ -21,7 +21,7 @@
     </p>
   </description>
   
-  <launchable type="desktop-id">input-remapper.desktop</launchable>
+  <launchable type="desktop-id">input-remapper-gtk.desktop</launchable>
   
   <screenshots>
     <screenshot type="default">


### PR DESCRIPTION
The .desktop file is installed as input-remapper-gtk.desktop, the metainfo should match.