### PR TITLE
Fix XDG_CONFIG_HOME being ignored

### DIFF
--- a/inputremapper/configs/paths.py
+++ b/inputremapper/configs/paths.py
@@ -32,14 +32,15 @@ from inputremapper.user import UserUtils
 
 # TODO maybe this could become, idk, ConfigService and PresetService
 class PathUtils:
-    rel_path = ".config/input-remapper-2"
-
     @staticmethod
     def config_path() -> str:
-        # TODO when proper DI is being done, construct PathUtils and configure it in
-        #  the constructor. Then there is no need to recompute the config_path
+        # TODO when proper DI is being done, construct PathUtils and configure it
+        #  in the constructor. Then there is no need to recompute the config_path
         #  each time. Tests might have overwritten UserUtils.home.
-        return os.path.join(UserUtils.home, PathUtils.rel_path)
+        xdg_config_home = os.getenv(
+            "XDG_CONFIG_HOME", os.path.join(UserUtils.home, ".config")
+        )
+        return os.path.join(xdg_config_home, "input-remapper-2")
 
     @staticmethod
     def chown(path):

--- a/tests/lib/patches.py
+++ b/tests/lib/patches.py
@@ -48,8 +48,12 @@ from tests.lib.logger import logger
 
 def patch_paths():
     from inputremapper.user import UserUtils
+    from inputremapper.configs.paths import PathUtils
 
-    return patch.object(UserUtils, "home", tmp)
+    return [
+        patch.object(UserUtils, "home", tmp),
+        patch.dict(os.environ, {"XDG_CONFIG_HOME": os.path.join(tmp, ".config")}),
+    ]
 
 
 class InputDevice:
@@ -393,7 +397,7 @@ def create_patches():
         patch_atexit_register(),
         patch_check_output(),
         # Those are comfortably wrapped in a class, and are therefore easy to patch
-        patch_paths(),
+        *patch_paths(),
         patch_regrab_timeout(),
         patch_is_running(),
         patch_events(),


### PR DESCRIPTION
Fixes #448
Closes #595

The location `~/.config` is a fallback to `$XDG_CONFIG_HOME` if the environment variable is not set,
as per [XDG Base Directory specification](https://specifications.freedesktop.org/basedir/latest/).