### PR TITLE
Use raw string literals for regexes

### DIFF
--- a/inputremapper/gui/controller.py
+++ b/inputremapper/gui/controller.py
@@ -330,7 +330,7 @@ class Controller:
     def copy_preset(self):
         """Create a copy of the active preset and name it `preset_name copy`."""
         name = self.data_manager.active_preset.name
-        match = re.search(" copy *\d*$", name)
+        match = re.search(r" copy *\d*$", name)
         if match:
             name = name[: match.start()]
 

--- a/inputremapper/gui/messages/message_broker.py
+++ b/inputremapper/gui/messages/message_broker.py
@@ -47,7 +47,7 @@ MessageListener = Callable[[Any], None]
 
 
 class MessageBroker:
-    shorten_path = re.compile("inputremapper/")
+    shorten_path = re.compile(r"inputremapper/")
 
     def __init__(self):
         self._listeners: Dict[MessageType, Set[MessageListener]] = defaultdict(set)

--- a/inputremapper/gui/messages/message_data.py
+++ b/inputremapper/gui/messages/message_data.py
@@ -42,7 +42,7 @@ class UInputsData:
 
         # find all sequences of comma+space separated numbers, and shorten them
         # to the first and last number
-        all_matches = list(re.finditer("(\d+, )+", string))
+        all_matches = list(re.finditer(r"(\d+, )+", string))
         all_matches.reverse()
         for match in all_matches:
             start = match.start()


### PR DESCRIPTION
This avoids confusion between Python escapes and regex escapes.

Reported in https://bugs.debian.org/1066817