### PR TITLE
Added Void Linux to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ sudo systemctl enable --now input-remapper
 
 <br/>
 
+### Void
+
+```sh
+sudo xbps-install -S input-remapper
+sudo ln -s /etc/sv/input-remapper /var/service
+sudo sv up input-remapper
+```
+
+<br/>
+
 ### Other Distros
 
 Figure out the packages providing those dependencies in your distro, and install them:


### PR DESCRIPTION
I'm now maintaining the package for this in Void's official repos, and can now be installed through it's package manager.
https://github.com/void-linux/void-packages/tree/master/srcpkgs/input-remapper