### PR TITLE
Fix memory leak in event_reader; autoload presets for all device instances

### DIFF
--- a/inputremapper/configs/global_config.py
+++ b/inputremapper/configs/global_config.py
@@ -51,10 +51,21 @@ class GlobalConfig:
         """The folder containing this config."""
         return os.path.split(self.path)[0]
 
-    def get_autoload_preset(self, group_key: str) -> Optional[str]:
+    def get_autoload_preset(
+        self, group_key: str, group_name: Optional[str] = None
+    ) -> Optional[str]:
         # modifications are only allowed via the setter, because it needs to write
         # the config file too. Therefore return a copy to prevent inconsistencies.
-        return copy.deepcopy(self._config["autoload"].get(group_key))
+        #
+        # First try an exact match on the group key (e.g. "Logitech MX Ergo 2").
+        # If that fails and a group_name is provided, fall back to matching by the
+        # base device name (e.g. "Logitech MX Ergo"). This allows a single config
+        # entry to cover all instances of the same device model, such as multiple
+        # pairing slots on a Logitech Unifying receiver.
+        result = self._config["autoload"].get(group_key)
+        if result is None and group_name is not None:
+            result = self._config["autoload"].get(group_name)
+        return copy.deepcopy(result)
 
     def set_autoload_preset(self, group_key: str, preset: Optional[str]):
         """Set a preset to be automatically applied on start.

--- a/inputremapper/daemon.py
+++ b/inputremapper/daemon.py
@@ -363,7 +363,7 @@ class Daemon:
             # either not relevant for input-remapper, or not connected yet
             return
 
-        preset = self.global_config.get_autoload_preset(group.key)
+        preset = self.global_config.get_autoload_preset(group.key, group.name)
 
         if preset is None:
             # no autoloading is configured for this device
@@ -433,8 +433,18 @@ class Daemon:
             logger.error("No presets configured to autoload")
             return
 
+        # Iterate all discovered groups, not just config keys. This allows a
+        # single autoload entry like "Logitech MX Ergo" to also match groups
+        # "Logitech MX Ergo 2", "Logitech MX Ergo 3", etc. via the name-based
+        # fallback in get_autoload_preset.
+        autoloaded_keys = set()
         for group_key, _ in autoload_presets:
             self._autoload(group_key)
+            autoloaded_keys.add(group_key)
+
+        for group in groups.filter():
+            if group.key not in autoloaded_keys:
+                self._autoload(group.key)
 
     def start_injecting(self, group_key: str, preset_name: str) -> bool:
         """Start injecting the preset for the device.

--- a/inputremapper/injection/event_reader.py
+++ b/inputremapper/injection/event_reader.py
@@ -80,34 +80,41 @@ class EventReader:
         self.stop_event.set()
 
     async def read_loop(self) -> AsyncIterator[evdev.InputEvent]:
-        stop_task = asyncio.Task(self.stop_event.wait())
         loop = asyncio.get_running_loop()
         events_ready = asyncio.Event()
         loop.add_reader(self._source.fileno(), events_ready.set)
 
-        while True:
-            _, pending = await asyncio.wait(
-                {stop_task, asyncio.Task(events_ready.wait())},
-                return_when=asyncio.FIRST_COMPLETED,
-            )
+        # A single task that wakes the loop when stop is requested, instead of
+        # creating a new asyncio.Task on every iteration.
+        async def _stop_watcher():
+            await self.stop_event.wait()
+            events_ready.set()
 
-            fd_broken = os.stat(self._source.fileno()).st_nlink == 0
-            if fd_broken:
-                # happens when the device is unplugged while reading, causing 100% cpu
-                # usage because events_ready.set is called repeatedly forever,
-                # while read_loop will hang at self._source.read_one().
-                logger.error("fd broke, was the device unplugged?")
+        watcher = asyncio.ensure_future(_stop_watcher())
 
-            if stop_task.done() or fd_broken:
-                for task in pending:
-                    task.cancel()
-                loop.remove_reader(self._source.fileno())
-                logger.debug("read loop stopped")
-                return
+        try:
+            while True:
+                await events_ready.wait()
+                events_ready.clear()
 
-            events_ready.clear()
-            while event := self._source.read_one():
-                yield event
+                fd_broken = os.stat(self._source.fileno()).st_nlink == 0
+                if fd_broken:
+                    # happens when the device is unplugged while reading,
+                    # causing 100% cpu usage because events_ready.set is called
+                    # repeatedly forever, while read_loop will hang at
+                    # self._source.read_one().
+                    logger.error("fd broke, was the device unplugged?")
+                    return
+
+                if self.stop_event.is_set():
+                    logger.debug("read loop stopped")
+                    return
+
+                while event := self._source.read_one():
+                    yield event
+        finally:
+            watcher.cancel()
+            loop.remove_reader(self._source.fileno())
 
     def send_to_handlers(self, event: InputEvent) -> bool:
         """Send the event to the NotifyCallbacks.
@@ -193,8 +200,6 @@ class EventReader:
 
         async for event in self.read_loop():
             try:
-                # Fire and forget, so that handlers and listeners can take their time,
-                # if they want to wait for something special to happen.
                 asyncio.ensure_future(
                     self.handle(
                         InputEvent.from_event(event, origin_hash=self._device_hash)


### PR DESCRIPTION
## Summary

- **Fix memory leak in EventReader**: `read_loop` created a new `asyncio.Task` on every input event to race `events_ready.wait()` against the stop task. For high-frequency devices (mice/trackballs at 125–1000 Hz), this produced billions of short-lived Task objects over days of uptime, fragmenting CPython's pymalloc arenas and causing monotonic RSS growth (~100 MB/day, observed 1.1 GB after 10 days). Replaced with a single `_stop_watcher` task that signals the shared `events_ready` Event, and `await events_ready.wait()` directly.

- **Autoload presets for all instances of the same device model**: When multiple pairing slots on a Logitech Unifying receiver expose the same device name (e.g. "Logitech MX Ergo", "Logitech MX Ergo 2"), only the first group matched the autoload config. `get_autoload_preset` now falls back to matching by the group's base device name, and `autoload()` iterates all discovered groups (filtering out input-remapper virtual devices) so every instance gets the preset.

## Test plan

- [x] Verify injection works for remapped devices after restart
- [ ] Monitor RSS of injector child process over hours/days — should stay flat
- [x] Test with multiple instances of the same device model (e.g. Unifying receiver with multiple slots)
- [ ] Test autoload with single-device config entry matching multiple group instances
- [ ] Verify input-remapper virtual devices are not passed to `_autoload`