### PR TITLE
Restrict 99-input-remapper.rules to event nodes

### DIFF
--- a/data/99-input-remapper.rules
+++ b/data/99-input-remapper.rules
@@ -7,4 +7,4 @@
 #   journalctl -f
 # to get available variables:
 #   udevadm monitor --environment --udev --subsystem input
-ACTION=="add", SUBSYSTEM=="input", ENV{ID_PATH}!="platform-sound", RUN+="/bin/input-remapper-control --command autoload --device $env{DEVNAME}"
+ACTION=="add", SUBSYSTEM=="input", KERNEL=="event*", ENV{ID_PATH}!="platform-sound", RUN+="/bin/input-remapper-control --command autoload --device $env{DEVNAME}"


### PR DESCRIPTION
## Summary

The udev rule fires synchronously for every add event in `SUBSYSTEM==input`. Most of those calls cannot succeed because the device is one of:

- a parent input class node with no `DEVNAME` (`input-remapper-control --command autoload --device ''` returns exit 2)
- a legacy `/dev/input/mouseN` or `/dev/input/mice` node (no group match, exit 1)
- a `/dev/input/jsN` joystick legacy node (no group match, exit 1)

Restricting the rule to `KERNEL=="event*"` keeps only the evdev nodes that input-remapper uses for group lookup. Every real input device exposes an event node, so no functionality is lost.

## Issues addressed

- **Fully addresses #588** (open since 2023-01-13, maintainer comment: "The udev rule is broken"). Eliminates all `input-remapper-control ... --device '' ... exit code 2` warnings that come from parent `inputN` class nodes firing the rule with empty `DEVNAME`.
- **Partially addresses #1284** (USB device reset loop on 8BitDo controller). The reporter's log shows three udev-rule firings per connect: `input31` exit 2, `js0` exit 5, and `event28` exit 5. This PR drops the first two but keeps `event28` firing. Whether the reset loop stops or persists depends on whether opening the `event*` node alone triggers the firmware bug on that device. The separate `/etc/xdg/autostart/input-remapper-autoload.desktop` autostart path that the reporter also disabled is outside the scope of this PR.

## Test plan

- [x] `udevadm control --reload-rules` then unplug/replug an input device
- [x] Verify `journalctl -u systemd-udevd` no longer shows `input-remapper-control [...] failed with exit code 1/2` from non-event nodes
- [x] Verify autoload still triggers for devices with a saved preset