### PR TITLE
fix: preserve forwarded mouse DPI metadata during injection

### DIFF
--- a/data/69-input-remapper-forwarded.rules
+++ b/data/69-input-remapper-forwarded.rules
@@ -1,0 +1,8 @@
+# helpful commands:
+#   udevadm monitor --property
+#   udevadm info --query=all --name=/dev/input/event3
+#
+# Forwarded input-remapper devices are virtual, so systemd's persistent-input
+# rules do not assign ID_BUS to them. Without ID_BUS, 70-mouse.rules will not
+# query hwdb and properties such as MOUSE_DPI get lost, changing pointer feel.
+ACTION=="add", SUBSYSTEM=="input", KERNEL=="event*", ATTRS{phys}=="input-remapper/*", ENV{ID_BUS}=="", ENV{ID_BUS}="usb"

--- a/data/99-input-remapper.rules
+++ b/data/99-input-remapper.rules
@@ -7,4 +7,4 @@
 #   journalctl -f
 # to get available variables:
 #   udevadm monitor --environment --udev --subsystem input
-ACTION=="add", SUBSYSTEM=="input", KERNEL=="event*", ENV{ID_PATH}!="platform-sound", RUN+="/bin/input-remapper-control --command autoload --device $env{DEVNAME}"
+ACTION=="add", SUBSYSTEM=="input", KERNEL=="event*", ENV{ID_PATH}!="platform-sound", ATTRS{phys}!="input-remapper*", RUN+="/bin/input-remapper-control --command autoload --device $env{DEVNAME}"

--- a/inputremapper/groups.py
+++ b/inputremapper/groups.py
@@ -492,17 +492,9 @@ class _Groups:
             keys = [f'"{group.key}"' for group in self._groups]
             logger.info("Found %s", ", ".join(keys))
 
-    def filter(self, include_inputremapper: bool = False) -> List[_Group]:
+    def filter(self) -> List[_Group]:
         """Filter groups."""
-        result = []
-        for group in self._groups:
-            name = group.name
-            if not include_inputremapper and name.startswith("input-remapper"):
-                continue
-
-            result.append(group)
-
-        return result
+        return list(self._groups)
 
     def set_groups(self, new_groups: List[_Group]):
         """Overwrite all groups."""
@@ -536,7 +528,6 @@ class _Groups:
         name: Optional[str] = None,
         key: Optional[str] = None,
         path: Optional[str] = None,
-        include_inputremapper: bool = False,
     ) -> Optional[_Group]:
         """Find a group that matches the provided parameters.
 
@@ -551,9 +542,6 @@ class _Groups:
             "/dev/input/event3"
         """
         for group in self._groups:
-            if not include_inputremapper and group.name.startswith("input-remapper"):
-                continue
-
             if name and group.name != name:
                 continue
 

--- a/inputremapper/groups.py
+++ b/inputremapper/groups.py
@@ -492,8 +492,8 @@ class _Groups:
             keys = [f'"{group.key}"' for group in self._groups]
             logger.info("Found %s", ", ".join(keys))
 
-    def filter(self) -> List[_Group]:
-        """Filter groups."""
+    def get_groups(self) -> List[_Group]:
+        """Return groups."""
         return list(self._groups)
 
     def set_groups(self, new_groups: List[_Group]):

--- a/inputremapper/groups.py
+++ b/inputremapper/groups.py
@@ -195,6 +195,13 @@ def classify(device) -> DeviceType:
 DENYLIST = [".*Yubico.*YubiKey.*", "Eee PC WMI hotkeys"]
 
 
+def is_inputremapper_device(device: evdev.InputDevice) -> bool:
+    """Return whether the device was created by input-remapper."""
+    name = str(device.name or "")
+    phys = str(device.phys or "")
+    return name.startswith("input-remapper") or phys.startswith("input-remapper")
+
+
 def is_denylisted(device: evdev.InputDevice):
     """Check if a device should not be used in input-remapper.
 
@@ -373,6 +380,10 @@ class _FindGroups(threading.Thread):
                 continue
 
             if device.name == "Power Button":
+                continue
+
+            if is_inputremapper_device(device):
+                logger.debug('Skipping input-remapper device "%s"', device.name)
                 continue
 
             device_type = classify(device)

--- a/inputremapper/gui/data_manager.py
+++ b/inputremapper/gui/data_manager.py
@@ -178,7 +178,7 @@ class DataManager:
 
     def get_group_keys(self) -> Tuple[GroupKey, ...]:
         """Get all group keys (plugged devices)."""
-        return tuple(group.key for group in self._reader_client.groups.filter())
+        return tuple(group.key for group in self._reader_client.groups.get_groups())
 
     def get_preset_names(self) -> Tuple[Name, ...]:
         """Get all preset names for active_group and current user sorted by age."""

--- a/inputremapper/gui/reader_client.py
+++ b/inputremapper/gui/reader_client.py
@@ -291,8 +291,7 @@ class ReaderClient:
     def publish_groups(self):
         """Announce all known groups."""
         groups: Dict[str, List[str]] = {
-            group.key: group.types or []
-            for group in self.groups.filter()
+            group.key: group.types or [] for group in self.groups.filter()
         }
         self.message_broker.publish(GroupsData(groups))
 

--- a/inputremapper/gui/reader_client.py
+++ b/inputremapper/gui/reader_client.py
@@ -291,7 +291,7 @@ class ReaderClient:
     def publish_groups(self):
         """Announce all known groups."""
         groups: Dict[str, List[str]] = {
-            group.key: group.types or [] for group in self.groups.filter()
+            group.key: group.types or [] for group in self.groups.get_groups()
         }
         self.message_broker.publish(GroupsData(groups))
 

--- a/inputremapper/gui/reader_client.py
+++ b/inputremapper/gui/reader_client.py
@@ -292,7 +292,7 @@ class ReaderClient:
         """Announce all known groups."""
         groups: Dict[str, List[str]] = {
             group.key: group.types or []
-            for group in self.groups.filter(include_inputremapper=False)
+            for group in self.groups.filter()
         }
         self.message_broker.publish(GroupsData(groups))
 

--- a/inputremapper/injection/injector.py
+++ b/inputremapper/injection/injector.py
@@ -89,6 +89,20 @@ def get_udev_name(name: str, suffix: str) -> str:
     return name
 
 
+def get_forward_phys(source: evdev.InputDevice) -> str:
+    """Use a stable phys marker for forwarded devices.
+
+    The original phys path must not be reused because it makes the forwarded
+    device look like the hardware device to our autoload rule. However, using a
+    dedicated input-remapper phys marker still allows us to identify and ignore
+    the forwarded device elsewhere.
+    """
+    if source.phys:
+        return f"{DEV_NAME}/{source.phys}"
+
+    return DEV_NAME
+
+
 @dataclass(frozen=True)
 class InjectorStateMessage:
     message_type = MessageType.injector_state
@@ -372,12 +386,14 @@ class Injector(multiprocessing.Process):
         # typing"
         try:
             forward_to = evdev.UInput(
-                name=get_udev_name(source.name, "forwarded"),
+                # Keep the original name so system hwdb rules can still match the
+                # virtual device and restore properties such as MOUSE_DPI.
+                name=source.name,
                 events=self._copy_capabilities(source),
-                # phys=source.phys,  # this leads to confusion. the appearance of
-                # a uinput with this "phys" property causes the udev rule to
-                # autoload for the original device, overwriting our previous
-                # attempts at starting an injection.
+                # Reusing source.phys causes our autoload rule to treat the
+                # forwarded device as hardware. Prefix it so it stays
+                # distinguishable while still carrying some source identity.
+                phys=get_forward_phys(source),
                 vendor=source.info.vendor,
                 product=source.info.product,
                 version=source.info.version,

--- a/install/data_files.py
+++ b/install/data_files.py
@@ -45,6 +45,7 @@ def get_data_files() -> list[tuple[str, list[str]]]:
         # which rendered the whole operating system unusable.
         ("usr/share/dbus-1/system.d/", ["data/inputremapper.Control.conf"]),
         ("etc/xdg/autostart/", ["data/input-remapper-autoload.desktop"]),
+        ("usr/lib/udev/rules.d", ["data/69-input-remapper-forwarded.rules"]),
         ("usr/lib/udev/rules.d", ["data/99-input-remapper.rules"]),
         ("usr/bin/", ["bin/input-remapper-gtk"]),
         ("usr/bin/", ["bin/input-remapper-service"]),

--- a/tests/lib/patches.py
+++ b/tests/lib/patches.py
@@ -210,13 +210,15 @@ uinputs = {}
 
 
 class UInputMock:
-    def __init__(self, events=None, name="unnamed", *args, **kwargs):
+    def __init__(
+        self, events=None, name="unnamed", phys="py-evdev-uinput", *args, **kwargs
+    ):
         self.fd = 0
         self.write_count = 0
         self.device = InputDevice("justdoit")
         self.name = name
         self.events = events
-        self.phys = kwargs.get("phys", "py-evdev-uinput")
+        self.phys = phys
         self.write_history = []
 
         global uinputs

--- a/tests/lib/patches.py
+++ b/tests/lib/patches.py
@@ -216,6 +216,7 @@ class UInputMock:
         self.device = InputDevice("justdoit")
         self.name = name
         self.events = events
+        self.phys = kwargs.get("phys", "py-evdev-uinput")
         self.write_history = []
 
         global uinputs

--- a/tests/unit/test_groups.py
+++ b/tests/unit/test_groups.py
@@ -176,7 +176,7 @@ class TestGroups(unittest.TestCase):
         }
 
         groups.refresh()
-        self.assertIsNone(groups.find(path="/foo/bar", include_inputremapper=True))
+        self.assertIsNone(groups.find(path="/foo/bar"))
 
     def test_is_inputremapper_device(self):
         device = evdev.InputDevice("/dev/input/event40")

--- a/tests/unit/test_groups.py
+++ b/tests/unit/test_groups.py
@@ -31,6 +31,7 @@ from inputremapper.groups import (
     classify,
     DeviceType,
     _Group,
+    is_inputremapper_device,
 )
 from tests.lib.fixtures import fixtures, keyboard_keys
 from tests.lib.test_setup import test_setup
@@ -125,14 +126,6 @@ class TestGroups(unittest.TestCase):
                     ),
                     json.dumps(
                         {
-                            "paths": ["/dev/input/event40"],
-                            "names": ["input-remapper Bar Device"],
-                            "types": [DeviceType.KEYBOARD],
-                            "key": "input-remapper Bar Device",
-                        }
-                    ),
-                    json.dumps(
-                        {
                             "paths": ["/dev/input/event52"],
                             "names": ["Qux/[Device]?"],
                             "types": [DeviceType.KEYBOARD],
@@ -166,6 +159,28 @@ class TestGroups(unittest.TestCase):
         keys = [group.key for group in filtered]
         self.assertIn("Foo Device 2", keys)
         self.assertNotIn("input-remapper Bar Device", keys)
+
+    def test_skip_inputremapper_phys_devices(self):
+        fixtures["/foo/bar"] = {
+            "name": "Logitech G Pro",
+            "phys": "input-remapper/usb-0000:0f:00.3-4.2/input2:1",
+            "info": evdev.DeviceInfo(3, 0x046D, 0x4079, 0x0111),
+            "capabilities": {
+                evdev.ecodes.EV_KEY: [evdev.ecodes.BTN_LEFT],
+                evdev.ecodes.EV_REL: [
+                    evdev.ecodes.REL_X,
+                    evdev.ecodes.REL_Y,
+                    evdev.ecodes.REL_WHEEL,
+                ],
+            },
+        }
+
+        groups.refresh()
+        self.assertIsNone(groups.find(path="/foo/bar", include_inputremapper=True))
+
+    def test_is_inputremapper_device(self):
+        device = evdev.InputDevice("/dev/input/event40")
+        self.assertTrue(is_inputremapper_device(device))
 
     def test_skip_camera(self):
         fixtures["/foo/bar"] = {

--- a/tests/unit/test_groups.py
+++ b/tests/unit/test_groups.py
@@ -136,7 +136,7 @@ class TestGroups(unittest.TestCase):
             ),
         )
 
-        groups2 = json.dumps([group.dumps() for group in groups.filter()])
+        groups2 = json.dumps([group.dumps() for group in groups.get_groups()])
         self.assertEqual(pipe.groups, groups2)
 
     def test_list_group_names(self):
@@ -151,9 +151,9 @@ class TestGroups(unittest.TestCase):
             ],
         )
 
-    def test_filter(self):
+    def test_get_groups(self):
         # by default no input-remapper devices are present
-        filtered = groups.filter()
+        filtered = groups.get_groups()
         keys = [group.key for group in filtered]
         self.assertIn("Foo Device 2", keys)
         self.assertNotIn("input-remapper Bar Device", keys)

--- a/tests/unit/test_groups.py
+++ b/tests/unit/test_groups.py
@@ -136,9 +136,7 @@ class TestGroups(unittest.TestCase):
             ),
         )
 
-        groups2 = json.dumps(
-            [group.dumps() for group in groups.filter(include_inputremapper=True)]
-        )
+        groups2 = json.dumps([group.dumps() for group in groups.filter()])
         self.assertEqual(pipe.groups, groups2)
 
     def test_list_group_names(self):

--- a/tests/unit/test_injector.py
+++ b/tests/unit/test_injector.py
@@ -58,6 +58,7 @@ from inputremapper.injection.injector import (
     is_in_capabilities,
     InjectorState,
     get_udev_name,
+    get_forward_phys,
 )
 from inputremapper.injection.numlock import is_numlock_on
 from inputremapper.input_event import InputEvent
@@ -287,6 +288,14 @@ class TestInjector(unittest.IsolatedAsyncioTestCase):
             "input-remapper abcd forwarded",
         )
 
+    def test_get_forward_phys(self):
+        path = "/dev/input/event11"
+        device = evdev.InputDevice(path)
+        self.assertEqual(
+            get_forward_phys(device),
+            "input-remapper/usb-0000:03:00.0-1/input2/input2",
+        )
+
     @mock.patch("evdev.InputDevice.ungrab")
     def test_capabilities_and_uinput_presence(self, ungrab_patch):
         preset = Preset()
@@ -359,8 +368,8 @@ class TestInjector(unittest.IsolatedAsyncioTestCase):
 
         # reading and preventing original events from reaching the
         # display server
-        forwarded_foo = uinputs.get("input-remapper Foo Device foo forwarded")
-        forwarded = uinputs.get("input-remapper Foo Device forwarded")
+        forwarded_foo = uinputs.get("Foo Device foo")
+        forwarded = uinputs.get("Foo Device")
         self.assertIsNotNone(forwarded_foo)
         self.assertIsNotNone(forwarded)
 
@@ -368,6 +377,8 @@ class TestInjector(unittest.IsolatedAsyncioTestCase):
         self.assertIn(EV_REL, forwarded_foo.capabilities())
         self.assertIn(EV_KEY, forwarded.capabilities())
         self.assertEqual(sorted(forwarded.capabilities()[EV_KEY]), keyboard_keys)
+        self.assertEqual(forwarded_foo.phys, "input-remapper/usb-0000:03:00.0-1/input2/input2")
+        self.assertEqual(forwarded.phys, "input-remapper/usb-0000:03:00.0-1/input2/input3")
 
         self.assertEqual(ungrab_patch.call_count, 2)
 

--- a/tests/unit/test_injector.py
+++ b/tests/unit/test_injector.py
@@ -377,8 +377,12 @@ class TestInjector(unittest.IsolatedAsyncioTestCase):
         self.assertIn(EV_REL, forwarded_foo.capabilities())
         self.assertIn(EV_KEY, forwarded.capabilities())
         self.assertEqual(sorted(forwarded.capabilities()[EV_KEY]), keyboard_keys)
-        self.assertEqual(forwarded_foo.phys, "input-remapper/usb-0000:03:00.0-1/input2/input2")
-        self.assertEqual(forwarded.phys, "input-remapper/usb-0000:03:00.0-1/input2/input3")
+        self.assertEqual(
+            forwarded_foo.phys, "input-remapper/usb-0000:03:00.0-1/input2/input2"
+        )
+        self.assertEqual(
+            forwarded.phys, "input-remapper/usb-0000:03:00.0-1/input2/input3"
+        )
 
         self.assertEqual(ungrab_patch.call_count, 2)
 

--- a/tests/unit/test_reader.py
+++ b/tests/unit/test_reader.py
@@ -907,14 +907,6 @@ class TestReaderMultiprocessing(unittest.TestCase):
                     ),
                     json.dumps(
                         {
-                            "paths": ["/dev/input/event40"],
-                            "names": ["input-remapper Bar Device"],
-                            "types": [DeviceType.KEYBOARD],
-                            "key": "input-remapper Bar Device",
-                        }
-                    ),
-                    json.dumps(
-                        {
                             "paths": ["/dev/input/event52"],
                             "names": ["Qux/[Device]?"],
                             "types": [DeviceType.KEYBOARD],


### PR DESCRIPTION
## Summary

This fixes a pointer feel regression when injecting mouse devices.

Before this change, the forwarded virtual mouse created by input-remapper
could lose hwdb-derived properties such as `MOUSE_DPI`. On devices like the
Logitech G Pro, that caused the injected pointer to feel different from the
original device even though the event capabilities were copied.

## What changed

- keep the forwarded device name identical to the source device so system
  mouse hwdb rules can still match
- assign a dedicated `input-remapper/...` phys path to forwarded devices so
  they remain distinguishable without reusing the original hardware phys
- add a udev rule that restores `ID_BUS` for forwarded devices before
  `70-mouse.rules` runs, allowing `MOUSE_DPI` to be applied
- prevent autoload and device discovery from treating input-remapper-created
  devices as real hardware
- update tests and local uinput mocks to cover forwarded phys handling and
  input-remapper device filtering

## Why

On my system, enabling injection for a Logitech G Pro changed the effective
pointer curve/DPI feel. Inspecting the injected device showed that the
forwarded virtual mouse was missing the original device's `MOUSE_DPI`
metadata.

After this patch, the forwarded device keeps the original device name, gets
`ID_BUS=usb`, and successfully receives the same `MOUSE_DPI` value as the
physical mouse.

## Verification

Manual verification on Linux with a Logitech G Pro:

- before the patch, the forwarded device had no `MOUSE_DPI`
- after the patch, both the physical device and the forwarded device expose:

  `MOUSE_DPI=400@1000 *800@1000 1600@1000 3200@1000 6400@1000`

- pointer feel is now indistinguishable during injection in real use

## Notes

I also observed unrelated instability in the local test environment on
Python 3.14, but the DPI/metadata fix itself was validated on the real
device.
