### PR TITLE
Fix similar devices stealing the injection on autoload

### DIFF
--- a/inputremapper/bin/input_remapper_control.py
+++ b/inputremapper/bin/input_remapper_control.py
@@ -139,7 +139,7 @@ class InputRemapperControlBin:
         logger.setLevel(logging.ERROR)
         from inputremapper.groups import groups
 
-        for group in groups:
+        for group in groups.get_groups():
             print(group.key)
 
     def list_key_names(self):
@@ -214,7 +214,7 @@ class InputRemapperControlBin:
             self.migrations.migrate()
 
     def _stop(self, device: str) -> None:
-        group = self._require_group(device)
+        group = self._load_group(device)
         self.daemon.stop_injecting(group.key)
 
     def _quit(self) -> None:
@@ -228,7 +228,7 @@ class InputRemapperControlBin:
             raise
 
     def _start(self, device: str, preset: str) -> None:
-        group = self._require_group(device)
+        group = self._load_group(device)
 
         logger.info(
             'Starting injection: "%s", "%s"',
@@ -238,7 +238,14 @@ class InputRemapperControlBin:
 
         self.daemon.start_injecting(group.key, preset)
 
-    def _require_group(self, device: str):
+    def _load_group(self, device: str):
+        """Load groups, check if a group exists for the given device and return it.
+        Crash if it can't be found.
+
+        device can be either a path like "/dev/input/event1" or a group key like
+        "USB Optical Mouse",
+        """
+
         # import stuff late to make sure the correct log level is applied
         # before anything is logged
         # TODO since imports shouldn't run any code, this is fixed by moving towards DI
@@ -247,6 +254,9 @@ class InputRemapperControlBin:
         if device is None:
             logger.error("--device missing")
             sys.exit(3)
+
+        # groups.find would also refresh it, but explicit is better than implicit
+        groups.refresh()
 
         if device.startswith("/dev"):
             group = groups.find(path=device)
@@ -269,8 +279,12 @@ class InputRemapperControlBin:
             logger.info("Autoloading all")
             self.daemon.autoload(timeout=10000)
         else:
-            group = self._require_group(device)
-            logger.info("Asking daemon to autoload for %s", device)
+            group = self._load_group(device)
+            logger.info(
+                "Asking daemon to autoload for device:%s group:%s",
+                device,
+                group.key,
+            )
             self.daemon.autoload_single(group.key, timeout=2000)
 
     def internals(self, command: str, debug: True) -> None:

--- a/inputremapper/bin/input_remapper_control.py
+++ b/inputremapper/bin/input_remapper_control.py
@@ -281,23 +281,23 @@ class InputRemapperControlBin:
         else:
             group = self._load_group(device)
             logger.info(
-                "Asking daemon to autoload for device:%s group:%s",
+                'Asking daemon to autoload for device "%s", group "%s"',
                 device,
                 group.key,
             )
             self.daemon.autoload_single(group.key, timeout=2000)
 
-    def internals(self, command: str, debug: True) -> None:
+    def internals(self, command: str, debug: bool) -> None:
         """Methods that are needed to get the gui to work and that require root.
 
         input-remapper-control should be started with sudo or pkexec for this.
         """
-        debug = " -d" if debug else ""
+        debug_flag = " -d" if debug else ""
 
         if command == Internals.START_READER_SERVICE.value:
-            cmd = f"input-remapper-reader-service{debug}"
+            cmd = f"input-remapper-reader-service{debug_flag}"
         elif command == Internals.START_DAEMON.value:
-            cmd = f"input-remapper-service --hide-info{debug}"
+            cmd = f"input-remapper-service --hide-info{debug_flag}"
         else:
             return
 

--- a/inputremapper/configs/migrations.py
+++ b/inputremapper/configs/migrations.py
@@ -162,9 +162,9 @@ class Migrations:
             return
 
         logger.info("Migrating presets from < 0.4.0...")
-        groups = os.listdir(PathUtils.config_path())
+        group_config_files = os.listdir(PathUtils.config_path())
         PathUtils.mkdir(PathUtils.get_preset_path())
-        for group in groups.get_groups():
+        for group in group_config_files:
             path = os.path.join(PathUtils.config_path(), group)
             if os.path.isdir(path):
                 target = path.replace(PathUtils.config_path(), new_preset_folder)

--- a/inputremapper/configs/migrations.py
+++ b/inputremapper/configs/migrations.py
@@ -164,7 +164,7 @@ class Migrations:
         logger.info("Migrating presets from < 0.4.0...")
         groups = os.listdir(PathUtils.config_path())
         PathUtils.mkdir(PathUtils.get_preset_path())
-        for group in groups:
+        for group in groups.get_groups():
             path = os.path.join(PathUtils.config_path(), group)
             if os.path.isdir(path):
                 target = path.replace(PathUtils.config_path(), new_preset_folder)

--- a/inputremapper/groups.py
+++ b/inputremapper/groups.py
@@ -487,12 +487,13 @@ class _Groups:
         pipe = multiprocessing.Pipe()
         _FindGroups(pipe[1]).start()
         # block until groups are available
-        self.loads(pipe[0].recv())
+        message = pipe[0].recv()
+        self.loads(message)
 
-        if len(self.get_groups()) == 0:
+        if len(self._groups) == 0:
             logger.error("Did not find any input device")
         else:
-            keys = [f'"{group.key}"' for group in self.get_groups()]
+            keys = [f'"{group.key}"' for group in self._groups]
             logger.info("Found %s", ", ".join(keys))
 
     def get_groups(self) -> List[_Group]:
@@ -520,7 +521,8 @@ class _Groups:
 
     def dumps(self):
         """Create a deserializable string representation."""
-        return json.dumps([group.dumps() for group in self.get_groups()])
+        groups = self.get_groups()
+        return json.dumps([group.dumps() for group in groups])
 
     def loads(self, dump: str):
         """Load a serialized representation created via dumps."""

--- a/inputremapper/groups.py
+++ b/inputremapper/groups.py
@@ -362,7 +362,21 @@ class _FindGroups(threading.Thread):
         # group them together by usb device because there could be stuff like
         # "Logitech USB Keyboard" and "Logitech USB Keyboard Consumer Control"
         grouped = {}
-        for path in evdev.list_devices():
+
+        # Sorting the paths is extremely important if two devices of the same make
+        # (two identical mice for example) are connected. Without sorting, the order
+        # depends on the order of plugging devices in. This causes the most recently
+        # plugged in device to get the first group.
+        # Without sorting:
+        # - mouse1 /input1 plugged in. group.key: "Mouse". Autoloads as configured.
+        # - mouse2 /input2 plugged in. group.key: "Mouse". mouse1 gets a different
+        #   group.key: "Mouse 2", even though an injection is running there. Bug.
+        # - I believe this is what causes input-remapper to stop the injection for
+        #   mouse1 and then start it for mouse2 instead. So plugging in a second
+        #   device breaks autoloading. Sorting fixes it.
+        # With sorting, mouse1 always gets group.key "Mouse", and mouse2 always
+        # "Mouse 2" (Unless only mouse2 is plugged in, then it gets "Mouse")
+        for path in sorted(evdev.list_devices()):
             try:
                 device = evdev.InputDevice(path)
             except Exception as error:
@@ -438,6 +452,7 @@ class _FindGroups(threading.Thread):
                 i += 1
             used_keys.add(key)
 
+            logger.debug('Creating group with key "%s", paths "%s"', key, devs)
             group = _Group(
                 key=key,
                 paths=devs,
@@ -462,18 +477,6 @@ class _Groups:
     def __init__(self):
         self._groups: List[_Group] = None
 
-    def __getattribute__(self, key: str):
-        """To lazy load group info only when needed.
-
-        For example, this helps to keep logs of input-remapper-control clear when it
-        doesn't need it the information.
-        """
-        if key == "_groups" and object.__getattribute__(self, "_groups") is None:
-            object.__setattr__(self, "_groups", [])
-            object.__getattribute__(self, "refresh")()
-
-        return object.__getattribute__(self, key)
-
     def refresh(self):
         """Look for devices and group them together.
 
@@ -486,14 +489,20 @@ class _Groups:
         # block until groups are available
         self.loads(pipe[0].recv())
 
-        if len(self._groups) == 0:
+        if len(self.get_groups()) == 0:
             logger.error("Did not find any input device")
         else:
-            keys = [f'"{group.key}"' for group in self._groups]
+            keys = [f'"{group.key}"' for group in self.get_groups()]
             logger.info("Found %s", ", ".join(keys))
 
     def get_groups(self) -> List[_Group]:
-        """Return groups."""
+        """Load groups and return them."""
+        if self._groups is None:
+            # To lazy load group info only when needed.
+            # For example, this helps to keep logs of input-remapper-control clear when
+            # it doesn't need it the information.
+            self.refresh()
+
         return list(self._groups)
 
     def set_groups(self, new_groups: List[_Group]):
@@ -509,15 +518,9 @@ class _Groups:
             if not group.name.startswith("input-remapper")
         ]
 
-    def __len__(self):
-        return len(self._groups)
-
-    def __iter__(self):
-        return iter(self._groups)
-
     def dumps(self):
         """Create a deserializable string representation."""
-        return json.dumps([group.dumps() for group in self._groups])
+        return json.dumps([group.dumps() for group in self.get_groups()])
 
     def loads(self, dump: str):
         """Load a serialized representation created via dumps."""
@@ -541,7 +544,7 @@ class _Groups:
         path
             "/dev/input/event3"
         """
-        for group in self._groups:
+        for group in self.get_groups():
             if name and group.name != name:
                 continue
 

--- a/inputremapper/gui/reader_client.py
+++ b/inputremapper/gui/reader_client.py
@@ -298,7 +298,7 @@ class ReaderClient:
     def _update_groups(self, dump: str):
         if dump != self.groups.dumps():
             self.groups.loads(dump)
-            logger.debug("Received %d devices", len(self.groups))
+            logger.debug("Received %d devices", len(self.groups.get_groups()))
             self._groups_updated = True
 
         # send this even if the groups did not change, as the user expects the ui

--- a/inputremapper/installation_info.py
+++ b/inputremapper/installation_info.py
@@ -27,4 +27,4 @@ COMMIT_HASH = "unknown"
 VERSION = "2.2.0"
 # depending on where this file is installed to, make sure to use the proper
 # prefix path for data.
-DATA_DIR = "/usr/share/inputremapper"
+DATA_DIR = "/usr/share/input-remapper"

--- a/tests/lib/fixtures.py
+++ b/tests/lib/fixtures.py
@@ -249,6 +249,9 @@ class _Fixtures:
     )
 
     def __init__(self):
+        self.reset()
+
+    def reset(self) -> None:
         self._iter = [
             self.dev_input_event1,
             self.dev_input_event11,
@@ -263,100 +266,115 @@ class _Fixtures:
             self.dev_input_event51,
             self.dev_input_event52,
         ]
-        self._dynamic_fixtures = {}
 
     def __getitem__(self, path: str) -> Fixture:
         """get a Fixture by it's unique /dev/input/eventX path"""
-        if fixture := self._dynamic_fixtures.get(path):
-            return fixture
-        path = self._path_to_attribute(path)
+        # TODO deprecate in favor of get_fixture
+        return self.get_fixture(path)
 
-        try:
-            return getattr(self, path)
-        except AttributeError as e:
-            raise KeyError(str(e))
+    def get_fixture(self, path: str) -> Fixture:
+        """get a Fixture by it's unique /dev/input/eventX path"""
+        for fixture in self._iter:
+            if fixture.path == path:
+                return fixture
 
-    def __setitem__(self, key: str, value: [Fixture | dict]):
+        raise KeyError(f"Could not find fixture with path {path}")
+
+    def __setitem__(self, key: str, value: Fixture | dict):
+        # TODO deprecate in favor of add_fixture
         if isinstance(value, Fixture):
-            self._dynamic_fixtures[key] = value
+            value = value.__dict__
+
+        kwargs = { **value }
+        kwargs["path"] = key
+        self.add_fixture(**kwargs)
+
+    def add_fixture(self, value: Fixture | dict) -> None:
+        if isinstance(value, Fixture):
+            value = value.__dict__
+
+        key = value["path"]
+        if isinstance(value, Fixture):
+            self._iter.append(value)
         elif isinstance(value, dict):
-            self._dynamic_fixtures[key] = Fixture(path=key, **value)
+            self._iter.append(Fixture(**value))
+
+    def remove_fixture(self, path: str) -> None:
+        index = 0
+        for i, fixture in enumerate(self._iter):
+            if fixture.path == path:
+                index = i
+
+        del self._iter[index]
 
     def __iter__(self):
-        return iter([*self._iter, *self._dynamic_fixtures.values()])
+        return iter(self._iter)
 
     def get_paths(self):
         """Get a list of all available device paths."""
-        return list(self._dynamic_fixtures.keys())
+        paths = []
+        for fixture in self._iter:
+            paths.append(fixture.path)
 
-    def reset(self):
-        self._dynamic_fixtures = {}
-
-    @staticmethod
-    def _path_to_attribute(path) -> str:
-        if path.startswith("/"):
-            path = path[1:]
-        if "/" in path:
-            path = path.replace("/", "_")
-        return path
+        return paths
 
     def get(self, item) -> Optional[Fixture]:
         try:
-            return self[item]
+            return self.get_fixture(item)
         except KeyError:
             return None
 
     @property
     def foo_device_1_1(self):
-        return self["/dev/input/event1"]
+        return self.get_fixture("/dev/input/event1")
 
     @property
     def foo_device_2_mouse(self):
-        return self["/dev/input/event11"]
+        return self.get_fixture("/dev/input/event11")
 
     @property
     def foo_device_2_keyboard(self):
-        return self["/dev/input/event10"]
+        return self.get_fixture("/dev/input/event10")
 
     @property
     def foo_device_2_13(self):
-        return self["/dev/input/event13"]
+        return self.get_fixture("/dev/input/event13")
 
     @property
     def foo_device_2_qux(self):
-        return self["/dev/input/event14"]
+        return self.get_fixture("/dev/input/event14")
 
     @property
     def foo_device_2_gamepad(self):
-        return self["/dev/input/event15"]
+        return self.get_fixture("/dev/input/event15")
 
     @property
     def bar_device(self):
-        return self["/dev/input/event20"]
+        return self.get_fixture("/dev/input/event20")
 
     @property
     def gamepad(self):
-        return self["/dev/input/event30"]
+        return self.get_fixture("/dev/input/event30")
 
     @property
     def power_button(self):
-        return self["/dev/input/event31"]
+        return self.get_fixture("/dev/input/event31")
 
     @property
     def input_remapper_bar_device(self):
-        return self["/dev/input/event40"]
+        return self.get_fixture("/dev/input/event40")
 
     @property
     def YuBiCofooYuBiKeYbar(self):
-        return self["/dev/input/event51"]
+        return self.get_fixture("/dev/input/event51")
 
     @property
     def QuxSlashDeviceQuestionmark(self):
-        return self["/dev/input/event52"]
+        return self.get_fixture("/dev/input/event52")
 
     @property
     def gamepad_abs_0_to_256(self):
-        return self["/dev/input/event32"]
+        return self.get_fixture("/dev/input/event32")
 
 
 fixtures = _Fixtures()

--- a/tests/lib/fixtures.py
+++ b/tests/lib/fixtures.py
@@ -267,11 +267,6 @@ class _Fixtures:
             self.dev_input_event52,
         ]
 
-    def __getitem__(self, path: str) -> Fixture:
-        """get a Fixture by it's unique /dev/input/eventX path"""
-        # TODO deprecate in favor of get_fixture
-        return self.get_fixture(path)
-
     def get_fixture(self, path: str) -> Fixture:
         """get a Fixture by it's unique /dev/input/eventX path"""
         for fixture in self._iter:
@@ -279,15 +274,6 @@ class _Fixtures:
                 return fixture
 
         raise KeyError(f"Could not find fixture with path {path}")
-
-    def __setitem__(self, key: str, value: Fixture | dict):
-        # TODO deprecate in favor of add_fixture
-        if isinstance(value, Fixture):
-            value = value.__dict__
-
-        kwargs = { **value }
-        kwargs["path"] = key
-        self.add_fixture(**kwargs)
 
     def add_fixture(self, value: Fixture | dict) -> None:
         if isinstance(value, Fixture):

--- a/tests/lib/fixtures.py
+++ b/tests/lib/fixtures.py
@@ -265,6 +265,7 @@ class _Fixtures:
             self.dev_input_event40,
             self.dev_input_event51,
             self.dev_input_event52,
+            self.dev_input_event32,
         ]
 
     def get_fixture(self, path: str) -> Fixture:

--- a/tests/lib/patches.py
+++ b/tests/lib/patches.py
@@ -73,7 +73,7 @@ class InputDevice:
         if path == "justdoit":
             self._fixture = Fixture(path="justdoit")
         else:
-            self._fixture = fixtures[path]
+            self._fixture = fixtures.get_fixture(path)
 
         self.path = path
         self.phys = self._fixture.phys

--- a/tests/system/test_dbus.py
+++ b/tests/system/test_dbus.py
@@ -74,7 +74,7 @@ class TestDBusDaemon(unittest.TestCase):
         # it's a remote dbus object
         introspection_xml = self.interface.Introspect()
         root = ET.fromstring(introspection_xml)
-        interfaces = [node.get('name') for node in root.findall('.//interface')]
+        interfaces = [node.get("name") for node in root.findall(".//interface")]
 
         self.assertIn(DAEMON.interface_name, interfaces)
         self.assertFalse(isinstance(self.interface, Daemon))

--- a/tests/system/test_dbus.py
+++ b/tests/system/test_dbus.py
@@ -22,6 +22,7 @@ import multiprocessing
 import os
 import time
 import unittest
+from xml.etree import ElementTree as ET
 
 import gi
 
@@ -67,11 +68,15 @@ class TestDBusDaemon(unittest.TestCase):
         self.assertFalse(is_service_running())
 
     def test_can_connect(self):
+        # Seriously what does this test even do? It checks if the correct interface
+        # name is set, apparently, which does not sound like "can_connect" at all.
+
         # it's a remote dbus object
-        self.assertEqual(
-            self.interface._interface_names["hello"],
-            DAEMON.interface_name,
-        )
+        introspection_xml = self.interface.Introspect()
+        root = ET.fromstring(introspection_xml)
+        interfaces = [node.get('name') for node in root.findall('.//interface')]
+
+        self.assertIn(DAEMON.interface_name, interfaces)
         self.assertFalse(isinstance(self.interface, Daemon))
         self.assertEqual(self.interface.hello("foo"), "foo")
 

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -258,7 +258,7 @@ class TestDaemon(unittest.TestCase):
             name=group_name,
             path=self.new_fixture_path,
         )
-        fixtures[self.new_fixture_path] = fixture
+        fixtures.add_fixture(fixture)
         push_events(fixture, [InputEvent.key(key_code, 1, fixture.get_device_hash())])
         self.daemon.start_injecting(group_key, preset_name)
 
@@ -293,12 +293,14 @@ class TestDaemon(unittest.TestCase):
 
         self.daemon.refresh()
 
-        fixtures[self.new_fixture_path] = Fixture(
-            capabilities={evdev.ecodes.EV_KEY: [evdev.ecodes.KEY_A]},
-            phys="9876 phys",
-            info=evdev.device.DeviceInfo(4, 5, 6, 7),
-            name=device_9876,
-            path=self.new_fixture_path,
+        fixtures.add_fixture(
+            Fixture(
+                capabilities={evdev.ecodes.EV_KEY: [evdev.ecodes.KEY_A]},
+                phys="9876 phys",
+                info=evdev.device.DeviceInfo(4, 5, 6, 7),
+                name=device_9876,
+                path=self.new_fixture_path,
+            )
         )
 
         self.daemon._autoload("25v7j9q4vtj")

--- a/tests/unit/test_groups.py
+++ b/tests/unit/test_groups.py
@@ -159,19 +159,22 @@ class TestGroups(unittest.TestCase):
         self.assertNotIn("input-remapper Bar Device", keys)
 
     def test_skip_inputremapper_phys_devices(self):
-        fixtures["/foo/bar"] = {
-            "name": "Logitech G Pro",
-            "phys": "input-remapper/usb-0000:0f:00.3-4.2/input2:1",
-            "info": evdev.DeviceInfo(3, 0x046D, 0x4079, 0x0111),
-            "capabilities": {
-                evdev.ecodes.EV_KEY: [evdev.ecodes.BTN_LEFT],
-                evdev.ecodes.EV_REL: [
-                    evdev.ecodes.REL_X,
-                    evdev.ecodes.REL_Y,
-                    evdev.ecodes.REL_WHEEL,
-                ],
-            },
-        }
+        fixtures.add_fixture(
+            {
+                "name": "Logitech G Pro",
+                "phys": "input-remapper/usb-0000:0f:00.3-4.2/input2:1",
+                "info": evdev.DeviceInfo(3, 0x046D, 0x4079, 0x0111),
+                "capabilities": {
+                    evdev.ecodes.EV_KEY: [evdev.ecodes.BTN_LEFT],
+                    evdev.ecodes.EV_REL: [
+                        evdev.ecodes.REL_X,
+                        evdev.ecodes.REL_Y,
+                        evdev.ecodes.REL_WHEEL,
+                    ],
+                },
+                "path": "/foo/bar",
+            }
+        )
 
         groups.refresh()
         self.assertIsNone(groups.find(path="/foo/bar"))
@@ -181,12 +184,15 @@ class TestGroups(unittest.TestCase):
         self.assertTrue(is_inputremapper_device(device))
 
     def test_skip_camera(self):
-        fixtures["/foo/bar"] = {
-            "name": "camera",
-            "phys": "abcd1",
-            "info": evdev.DeviceInfo(1, 2, 3, 4),
-            "capabilities": {evdev.ecodes.EV_KEY: [evdev.ecodes.KEY_CAMERA]},
-        }
+        fixtures.add_fixture(
+            {
+                "name": "camera",
+                "phys": "abcd1",
+                "info": evdev.DeviceInfo(1, 2, 3, 4),
+                "capabilities": {evdev.ecodes.EV_KEY: [evdev.ecodes.KEY_CAMERA]},
+                "path": "/foo/bar",
+            }
+        )
 
         groups.refresh()
         self.assertIsNone(groups.find(name="camera"))
@@ -195,37 +201,45 @@ class TestGroups(unittest.TestCase):
     def test_device_with_only_ev_abs(self):
         # As Input Mapper can now map axes to buttons,
         # a single EV_ABS device is valid for mapping.
-        fixtures["/foo/bar"] = {
-            "name": "qux",
-            "phys": "abcd2",
-            "info": evdev.DeviceInfo(1, 2, 3, 4),
-            "capabilities": {evdev.ecodes.EV_ABS: [evdev.ecodes.ABS_X]},
-        }
+        fixtures.add_fixture(
+            {
+                "name": "qux",
+                "phys": "abcd2",
+                "info": evdev.DeviceInfo(1, 2, 3, 4),
+                "capabilities": {evdev.ecodes.EV_ABS: [evdev.ecodes.ABS_X]},
+                "path": "/foo/bar",
+            }
+        )
 
         groups.refresh()
         self.assertIsNotNone(groups.find(name="gamepad"))
         self.assertIsNotNone(groups.find(name="qux"))
 
     def test_device_with_no_capabilities(self):
-        fixtures["/foo/bar"] = {
-            "name": "nulcap",
-            "phys": "abcd3",
-            "info": evdev.DeviceInfo(1, 2, 3, 4),
-            "capabilities": {},
-        }
+        fixtures.add_fixture(
+            {
+                "name": "nulcap",
+                "phys": "abcd3",
+                "info": evdev.DeviceInfo(1, 2, 3, 4),
+                "capabilities": {},
+                "path": "/foo/bar",
+            }
+        )
 
         groups.refresh()
         self.assertIsNotNone(groups.find(name="gamepad"))
         self.assertIsNone(groups.find(name="nulcap"))
 
     def test_duplicate_device(self):
-        fixtures.add_fixture({
-            "capabilities": {evdev.ecodes.EV_KEY: keyboard_keys},
-            "phys": "usb-0000:03:00.0-3/input1",
-            "info": evdev.device.DeviceInfo(2, 1, 2, 1),
-            "name": "Foo Device",
-            "path": "/dev/input/event100",
-        })
+        fixtures.add_fixture(
+            {
+                "capabilities": {evdev.ecodes.EV_KEY: keyboard_keys},
+                "phys": "usb-0000:03:00.0-3/input1",
+                "info": evdev.device.DeviceInfo(2, 1, 2, 1),
+                "name": "Foo Device",
+                "path": "/dev/input/event100",
+            }
+        )
 
         groups.refresh()
         group1 = groups.find(key="Foo Device")

--- a/tests/unit/test_groups.py
+++ b/tests/unit/test_groups.py
@@ -271,7 +271,10 @@ class TestGroups(unittest.TestCase):
         backup = fixtures.get_fixture("/dev/input/event1")
         fixtures.remove_fixture("/dev/input/event1")
         fixtures.add_fixture(backup)
-        # Now the order should be messed up
+        # Now the order should be messed up (This is acceptable here, as long as the
+        # groups end up in the correct original order. This check only exists to make
+        # sure the test would still be able to reproduce the bug. The order being
+        # messed up is a prerequisite to reproduce the bug)
         paths = fixtures.get_paths()
         self.assertGreater(
             paths.index("/dev/input/event1"),

--- a/tests/unit/test_groups.py
+++ b/tests/unit/test_groups.py
@@ -117,8 +117,14 @@ class TestGroups(unittest.TestCase):
                 ),
                 json.dumps(
                     {
-                        "paths": ["/dev/input/event30"],
-                        "names": ["gamepad"],
+                        "paths": [
+                            "/dev/input/event30",
+                            "/dev/input/event32",
+                        ],
+                        "names": [
+                            "gamepad",
+                            "gamepad abs 0 to 256",
+                        ],
                         "types": [DeviceType.GAMEPAD],
                         "key": "gamepad",
                     }

--- a/tests/unit/test_groups.py
+++ b/tests/unit/test_groups.py
@@ -72,69 +72,69 @@ class TestGroups(unittest.TestCase):
 
         groups.loads(pipe.groups)
         self.maxDiff = None
-        self.assertEqual(
-            groups.dumps(),
-            json.dumps(
-                [
-                    json.dumps(
-                        {
-                            "paths": [
-                                "/dev/input/event1",
-                            ],
-                            "names": ["Foo Device"],
-                            "types": [DeviceType.KEYBOARD],
-                            "key": "Foo Device",
-                        }
-                    ),
-                    json.dumps(
-                        {
-                            "paths": [
-                                "/dev/input/event11",
-                                "/dev/input/event10",
-                                "/dev/input/event13",
-                                "/dev/input/event15",
-                            ],
-                            "names": [
-                                "Foo Device foo",
-                                "Foo Device",
-                                "Foo Device",
-                                "Foo Device bar",
-                            ],
-                            "types": [
-                                DeviceType.GAMEPAD,
-                                DeviceType.KEYBOARD,
-                                DeviceType.MOUSE,
-                            ],
-                            "key": "Foo Device 2",
-                        }
-                    ),
-                    json.dumps(
-                        {
-                            "paths": ["/dev/input/event20"],
-                            "names": ["Bar Device"],
-                            "types": [DeviceType.KEYBOARD],
-                            "key": "Bar Device",
-                        }
-                    ),
-                    json.dumps(
-                        {
-                            "paths": ["/dev/input/event30"],
-                            "names": ["gamepad"],
-                            "types": [DeviceType.GAMEPAD],
-                            "key": "gamepad",
-                        }
-                    ),
-                    json.dumps(
-                        {
-                            "paths": ["/dev/input/event52"],
-                            "names": ["Qux/[Device]?"],
-                            "types": [DeviceType.KEYBOARD],
-                            "key": "Qux/[Device]?",
-                        }
-                    ),
-                ]
-            ),
+        dump1 = groups.dumps()
+        dump2 = json.dumps(
+            [
+                json.dumps(
+                    {
+                        "paths": [
+                            "/dev/input/event1",
+                        ],
+                        "names": ["Foo Device"],
+                        "types": [DeviceType.KEYBOARD],
+                        "key": "Foo Device",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "paths": [
+                            "/dev/input/event10",
+                            "/dev/input/event11",
+                            "/dev/input/event13",
+                            "/dev/input/event15",
+                        ],
+                        "names": [
+                            "Foo Device",
+                            "Foo Device foo",
+                            "Foo Device",
+                            "Foo Device bar",
+                        ],
+                        "types": [
+                            DeviceType.GAMEPAD,
+                            DeviceType.KEYBOARD,
+                            DeviceType.MOUSE,
+                        ],
+                        "key": "Foo Device 2",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "paths": ["/dev/input/event20"],
+                        "names": ["Bar Device"],
+                        "types": [DeviceType.KEYBOARD],
+                        "key": "Bar Device",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "paths": ["/dev/input/event30"],
+                        "names": ["gamepad"],
+                        "types": [DeviceType.GAMEPAD],
+                        "key": "gamepad",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "paths": ["/dev/input/event52"],
+                        "names": ["Qux/[Device]?"],
+                        "types": [DeviceType.KEYBOARD],
+                        "key": "Qux/[Device]?",
+                    }
+                ),
+            ]
         )
+
+        self.assertEqual(dump1, dump2)
 
         groups2 = json.dumps([group.dumps() for group in groups.get_groups()])
         self.assertEqual(pipe.groups, groups2)

--- a/tests/unit/test_groups.py
+++ b/tests/unit/test_groups.py
@@ -33,7 +33,7 @@ from inputremapper.groups import (
     _Group,
     is_inputremapper_device,
 )
-from tests.lib.fixtures import fixtures, keyboard_keys
+from tests.lib.fixtures import fixtures, keyboard_keys, Fixture
 from tests.lib.test_setup import test_setup
 
 
@@ -219,26 +219,63 @@ class TestGroups(unittest.TestCase):
         self.assertIsNone(groups.find(name="nulcap"))
 
     def test_duplicate_device(self):
-        fixtures["/dev/input/event100"] = {
+        fixtures.add_fixture({
             "capabilities": {evdev.ecodes.EV_KEY: keyboard_keys},
             "phys": "usb-0000:03:00.0-3/input1",
             "info": evdev.device.DeviceInfo(2, 1, 2, 1),
             "name": "Foo Device",
-        }
-        groups.refresh()
+            "path": "/dev/input/event100",
+        })
 
+        groups.refresh()
         group1 = groups.find(key="Foo Device")
         group2 = groups.find(key="Foo Device 2")
         group3 = groups.find(key="Foo Device 3")
-
         self.assertIn("/dev/input/event1", group1.paths)
         self.assertIn("/dev/input/event10", group2.paths)
         self.assertIn("/dev/input/event100", group3.paths)
-
         self.assertEqual(group1.key, "Foo Device")
         self.assertEqual(group2.key, "Foo Device 2")
         self.assertEqual(group3.key, "Foo Device 3")
+        self.assertEqual(group1.name, "Foo Device")
+        self.assertEqual(group2.name, "Foo Device")
+        self.assertEqual(group3.name, "Foo Device")
 
+        # Bug reproduction: Unplugging a device and plugging it back in makes it appear
+        # earlier in the detected devices, giving it the first group, causing it to
+        # steal other devices injections on autoload.
+
+        # Make sure the first fixture is earlier in the list than the third fixture.
+        # This is the starting situation, everything is still fine.
+        paths = fixtures.get_paths()
+        self.assertLess(
+            paths.index("/dev/input/event1"),
+            paths.index("/dev/input/event100"),
+        )
+
+        # Remove the first group, and add it back in
+        backup = fixtures.get_fixture("/dev/input/event1")
+        fixtures.remove_fixture("/dev/input/event1")
+        fixtures.add_fixture(backup)
+        # Now the order should be messed up
+        paths = fixtures.get_paths()
+        self.assertGreater(
+            paths.index("/dev/input/event1"),
+            paths.index("/dev/input/event100"),
+        )
+
+        # refreshing groups should still end up giving each device the same group as
+        # before.
+        groups.refresh()
+        group1 = groups.find(key="Foo Device")
+        group2 = groups.find(key="Foo Device 2")
+        group3 = groups.find(key="Foo Device 3")
+        self.assertIn("/dev/input/event1", group1.paths)
+        self.assertIn("/dev/input/event10", group2.paths)
+        self.assertIn("/dev/input/event100", group3.paths)
+        self.assertEqual(group1.key, "Foo Device")
+        self.assertEqual(group2.key, "Foo Device 2")
+        self.assertEqual(group3.key, "Foo Device 3")
         self.assertEqual(group1.name, "Foo Device")
         self.assertEqual(group2.name, "Foo Device")
         self.assertEqual(group3.name, "Foo Device")

--- a/tests/unit/test_injector.py
+++ b/tests/unit/test_injector.py
@@ -143,7 +143,7 @@ class TestInjector(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(gamepad)
         self.assertEqual(self.failed, 2)
         # success on the third try
-        self.assertEqual(device.name, fixtures[path].name)
+        self.assertEqual(device.name, fixtures.get_fixture(path).name)
 
     def test_fail_grab(self):
         self.make_it_fail = 999

--- a/tests/unit/test_reader.py
+++ b/tests/unit/test_reader.py
@@ -229,7 +229,7 @@ class TestReaderMultiprocessing(unittest.TestCase):
                 InputCombination(
                     [
                         InputConfig(
-                            type=3,
+                            type=EV_ABS,
                             code=16,
                             analog_threshold=DEFAULT_ABS_ANALOG_THRESHOLD_MAGNITUDE,
                             origin_hash=fixtures.foo_device_2_gamepad.get_device_hash(),
@@ -241,7 +241,7 @@ class TestReaderMultiprocessing(unittest.TestCase):
                 InputCombination(
                     [
                         InputConfig(
-                            type=3,
+                            type=EV_ABS,
                             code=16,
                             analog_threshold=DEFAULT_ABS_ANALOG_THRESHOLD_MAGNITUDE,
                             origin_hash=fixtures.foo_device_2_gamepad.get_device_hash(),
@@ -389,9 +389,8 @@ class TestReaderMultiprocessing(unittest.TestCase):
                     InputCombination(
                         [
                             InputConfig(
-                                type=1,
+                                type=EV_KEY,
                                 code=30,
-                                analog_threshold=DEFAULT_ABS_ANALOG_THRESHOLD_MAGNITUDE,
                                 origin_hash=fixtures.foo_device_2_keyboard.get_device_hash(),
                             )
                         ]
@@ -423,7 +422,7 @@ class TestReaderMultiprocessing(unittest.TestCase):
                     InputCombination(
                         [
                             InputConfig(
-                                type=3,
+                                type=EV_ABS,
                                 code=0,
                                 analog_threshold=DEFAULT_ABS_ANALOG_THRESHOLD_MAGNITUDE,
                                 origin_hash=fixtures.foo_device_2_gamepad.get_device_hash(),
@@ -449,7 +448,7 @@ class TestReaderMultiprocessing(unittest.TestCase):
                     InputCombination(
                         [
                             InputConfig(
-                                type=3,
+                                type=EV_ABS,
                                 code=0,
                                 analog_threshold=DEFAULT_ABS_ANALOG_THRESHOLD_MAGNITUDE,
                                 origin_hash=fixtures.foo_device_2_gamepad.get_device_hash(),

--- a/tests/unit/test_reader.py
+++ b/tests/unit/test_reader.py
@@ -642,12 +642,15 @@ class TestReaderMultiprocessing(unittest.TestCase):
 
         pipe = multiprocessing.Pipe()
 
+        groups = _Groups()
+
         def refresh():
             # from within the reader-service process notify this test that
             # refresh was called as expected
             pipe[1].send("refreshed")
+            # call original method
+            return _Groups.refresh(groups)
 
-        groups = _Groups()
         groups.refresh = refresh
         self.create_reader_service(groups)
 

--- a/tests/unit/test_reader.py
+++ b/tests/unit/test_reader.py
@@ -901,8 +901,14 @@ class TestReaderMultiprocessing(unittest.TestCase):
                     ),
                     json.dumps(
                         {
-                            "paths": ["/dev/input/event30"],
-                            "names": ["gamepad"],
+                            "paths": [
+                                "/dev/input/event30",
+                                "/dev/input/event32",
+                            ],
+                            "names": [
+                                "gamepad",
+                                "gamepad abs 0 to 256",
+                            ],
                             "types": [DeviceType.GAMEPAD],
                             "key": "gamepad",
                         }

--- a/tests/unit/test_reader.py
+++ b/tests/unit/test_reader.py
@@ -869,14 +869,14 @@ class TestReaderMultiprocessing(unittest.TestCase):
                     json.dumps(
                         {
                             "paths": [
-                                "/dev/input/event11",
                                 "/dev/input/event10",
+                                "/dev/input/event11",
                                 "/dev/input/event13",
                                 "/dev/input/event15",
                             ],
                             "names": [
-                                "Foo Device foo",
                                 "Foo Device",
+                                "Foo Device foo",
                                 "Foo Device",
                                 "Foo Device bar",
                             ],

--- a/tests/unit/test_test.py
+++ b/tests/unit/test_test.py
@@ -67,7 +67,7 @@ class TestTest(unittest.TestCase):
         self.assertIsInstance(capabilities[EV_KEY][0], int)
 
     def test_restore_fixtures(self):
-        fixtures["/bar/dev"] = {"name": "bla"}
+        fixtures.add_fixture({"name": "bla", "path": "/bar/dev"})
         cleanup()
         self.assertIsNone(fixtures.get("/bar/dev"))
         self.assertIsNotNone(fixtures.get("/dev/input/event11"))


### PR DESCRIPTION
Possibly related to https://github.com/sezanzeb/input-remapper/issues/1300

Also improves how fixtures are managed in tests, and some other improvements in code readability/maintainability