### PR TITLE
Limit forwarded uinput device names

### DIFF
--- a/inputremapper/injection/injector.py
+++ b/inputremapper/injection/injector.py
@@ -89,6 +89,11 @@ def get_udev_name(name: str, suffix: str) -> str:
     return name
 
 
+def get_forward_name(name: str) -> str:
+    """Keep forwarded uinput names within evdev's 80 character limit."""
+    return name[:80]
+
+
 def get_forward_phys(source: evdev.InputDevice) -> str:
     """Use a stable phys marker for forwarded devices.
 
@@ -386,9 +391,10 @@ class Injector(multiprocessing.Process):
         # typing"
         try:
             forward_to = evdev.UInput(
-                # Keep the original name so system hwdb rules can still match the
-                # virtual device and restore properties such as MOUSE_DPI.
-                name=source.name,
+                # Keep the original name as far as possible so system hwdb rules
+                # can still match the virtual device and restore properties such
+                # as MOUSE_DPI.
+                name=get_forward_name(source.name),
                 events=self._copy_capabilities(source),
                 # Reusing source.phys causes our autoload rule to treat the
                 # forwarded device as hardware. Prefix it so it stays

--- a/tests/unit/test_injector.py
+++ b/tests/unit/test_injector.py
@@ -58,6 +58,7 @@ from inputremapper.injection.injector import (
     is_in_capabilities,
     InjectorState,
     get_udev_name,
+    get_forward_name,
     get_forward_phys,
 )
 from inputremapper.injection.numlock import is_numlock_on
@@ -295,6 +296,10 @@ class TestInjector(unittest.IsolatedAsyncioTestCase):
             get_forward_phys(device),
             "input-remapper/usb-0000:03:00.0-1/input2/input2",
         )
+
+    def test_get_forward_name(self):
+        self.assertEqual(get_forward_name("a" * 100), "a" * 80)
+        self.assertEqual(get_forward_name("abcd"), "abcd")
 
     @mock.patch("evdev.InputDevice.ungrab")
     def test_capabilities_and_uinput_presence(self, ungrab_patch):


### PR DESCRIPTION
Fixes #1297.
Truncates forwarded uinput device names to evdev's 80 character limit while keeping them close to the source name for hwdb matching.