### PR TITLE
fix(injector): read from all devnodes sharing an origin_hash

### DIFF
--- a/inputremapper/injection/injector.py
+++ b/inputremapper/injection/injector.py
@@ -46,7 +46,7 @@ from inputremapper.injection.event_reader import EventReader
 from inputremapper.injection.mapping_handlers.mapping_parser import MappingParser
 from inputremapper.injection.numlock import set_numlock, is_numlock_on, ensure_numlock
 from inputremapper.logging.logger import logger
-from inputremapper.utils import get_device_hash, DeviceHash
+from inputremapper.utils import get_device_hash
 
 CapabilitiesDict = Dict[int, List[int]]
 
@@ -216,21 +216,38 @@ class Injector(multiprocessing.Process):
 
     """Process internal stuff."""
 
-    def _find_input_device(
-        self, input_config: InputConfig
-    ) -> Optional[evdev.InputDevice]:
-        """find the InputDevice specified by the InputConfig
+    def _find_input_devices(self, input_config: InputConfig) -> List[evdev.InputDevice]:
+        """Find all InputDevices the InputConfig's origin_hash points to.
 
-        ensures the devices supports the type and code specified by the InputConfig"""
-        devices_by_hash = {get_device_hash(device): device for device in self._devices}
+        The origin_hash records the exact /dev/input/eventXX node an event was
+        observed on while the mapping was created. Because get_device_hash
+        incorporates the device's capabilities, a matching hash guarantees the
+        node still has the same capabilities it had back then, so it is always
+        the correct node to read from.
 
-        # mypy thinks None is the wrong type for dict.get()
-        if device := devices_by_hash.get(input_config.origin_hash):  # type: ignore
-            if input_config.code in device.capabilities(absinfo=False).get(
-                input_config.type, []
-            ):
-                return device
-        return None
+        Two things this intentionally handles:
+
+        1. Multiple matches. get_device_hash is md5(capabilities + name), which
+           is *not* unique per devnode: some hardware (e.g. SteelSeries wireless
+           mice) exposes several event nodes with byte-identical capabilities
+           and name, so they share an origin_hash. The actual event may be
+           emitted on any one of them and we cannot tell in advance which, so we
+           must read from all of them. Returning only one (as a hash-keyed dict
+           would) makes the injector grab the wrong twin and silently miss the
+           event.
+
+        2. No capability gate. We do NOT additionally require that
+           input_config.code is listed in a node's advertised capabilities.
+           Some nodes emit codes that are not in their static capabilities;
+           requiring the capability would discard a valid origin_hash and let
+           _update_preset fall back to a different node that merely advertises
+           the code but never receives the event.
+        """
+        return [
+            device
+            for device in self._devices
+            if get_device_hash(device) == input_config.origin_hash
+        ]
 
     def _find_input_device_fallback(
         self, input_config: InputConfig
@@ -262,8 +279,14 @@ class Injector(multiprocessing.Process):
         logger.error(f"Could not find input for {input_config}")
         return None
 
-    def _grab_devices(self) -> Dict[DeviceHash, evdev.InputDevice]:
-        """Grab all InputDevices that match a mappings' origin_hash."""
+    def _grab_devices(self) -> Dict[str, evdev.InputDevice]:
+        """Grab all InputDevices that match a mappings' origin_hash.
+
+        Keyed by device path, not by device hash: multiple devnodes can share
+        an origin_hash (see _find_input_devices), and all of them need to be
+        grabbed and read from. Keying by hash would collapse such collisions
+        into a single node and miss events emitted on the others.
+        """
         # use a dict because the InputDevice is not directly hashable
         needed_devices = {}
         input_configs = set()
@@ -275,16 +298,15 @@ class Injector(multiprocessing.Process):
 
         # find all unique input_device's
         for input_config in input_configs:
-            if not (device := self._find_input_device(input_config)):
-                # there is no point in trying the fallback because
-                # self._update_preset already did that.
-                continue
-            needed_devices[device.path] = device
+            # there is no point in trying the fallback because
+            # self._update_preset already did that.
+            for device in self._find_input_devices(input_config):
+                needed_devices[device.path] = device
 
         grabbed_devices = {}
         for device in needed_devices.values():
             if device := self._grab_device(device):
-                grabbed_devices[get_device_hash(device)] = device
+                grabbed_devices[device.path] = device
 
         return grabbed_devices
 
@@ -297,7 +319,7 @@ class Injector(multiprocessing.Process):
                 mappings_by_input[input_config].append(mapping)
 
         for input_config in mappings_by_input:
-            if self._find_input_device(input_config):
+            if self._find_input_devices(input_config):
                 continue
 
             if not (device := self._find_input_device_fallback(input_config)):
@@ -444,15 +466,24 @@ class Injector(multiprocessing.Process):
         # grab devices as early as possible. If events appear that won't get
         # released anymore before the grab they appear to be held down forever
         sources = self._grab_devices()
+        # sources is keyed by path so every grabbed devnode gets its own read
+        # loop below. The Context however is keyed by device hash, because events
+        # are matched and forwarded based on their origin_hash. Devnodes that
+        # share a hash (see _find_input_devices) are interchangeable for the
+        # Context, so one entry per unique hash is enough.
+        source_devices = {}
         forward_devices = {}
-        for device_hash, device in sources.items():
-            forward_devices[device_hash] = self._create_forwarding_device(device)
+        for device in sources.values():
+            device_hash = get_device_hash(device)
+            if device_hash not in forward_devices:
+                source_devices[device_hash] = device
+                forward_devices[device_hash] = self._create_forwarding_device(device)
 
         # create this within the process after the event loop creation,
         # so that the macros use the correct loop
         self.context = Context(
             self.preset,
-            sources,
+            source_devices,
             forward_devices,
             self.mapping_parser,
         )
@@ -467,11 +498,12 @@ class Injector(multiprocessing.Process):
         numlock_state = is_numlock_on()
         coroutines = []
 
-        for device_hash in sources:
-            # actually doing things
+        for source in sources.values():
+            # one read loop per devnode. Nodes that share a device hash each
+            # get their own reader, so an event emitted on any of them is read.
             event_reader = EventReader(
                 self.context,
-                sources[device_hash],
+                source,
                 self._stop_event,
             )
             coroutines.append(event_reader.run())

--- a/tests/unit/test_injector.py
+++ b/tests/unit/test_injector.py
@@ -51,7 +51,7 @@ from inputremapper.configs.keyboard_layout import (
     DISABLE_CODE,
     DISABLE_NAME,
 )
-from inputremapper.groups import groups, classify, DeviceType
+from inputremapper.groups import groups, classify, DeviceType, _Group
 from inputremapper.injection.context import Context
 from inputremapper.injection.injector import (
     Injector,
@@ -65,7 +65,7 @@ from inputremapper.injection.numlock import is_numlock_on
 from inputremapper.input_event import InputEvent
 
 from tests.lib.constants import EVENT_READ_TIMEOUT
-from tests.lib.fixtures import fixtures
+from tests.lib.fixtures import fixtures, Fixture
 from tests.lib.fixtures import keyboard_keys
 from tests.lib.patches import uinputs
 from tests.lib.pipes import read_write_history_pipe, push_events
@@ -207,7 +207,7 @@ class TestInjector(unittest.IsolatedAsyncioTestCase):
 
         grabbed = self.injector._grab_devices()
         self.assertEqual(len(grabbed), 1)
-        self.assertEqual(grabbed[device_hash].path, "/dev/input/event30")
+        self.assertEqual(grabbed["/dev/input/event30"].path, "/dev/input/event30")
 
     def test_forward_gamepad_events(self):
         device_hash = fixtures.gamepad.get_device_hash()
@@ -230,8 +230,8 @@ class TestInjector(unittest.IsolatedAsyncioTestCase):
         path = "/dev/input/event30"
         devices = self.injector._grab_devices()
         self.assertEqual(len(devices), 1)
-        self.assertEqual(devices[device_hash].path, path)
-        gamepad = classify(devices[device_hash]) == DeviceType.GAMEPAD
+        self.assertEqual(devices[path].path, path)
+        gamepad = classify(devices[path]) == DeviceType.GAMEPAD
         self.assertTrue(gamepad)
 
     def test_skip_unused_device(self):
@@ -270,6 +270,171 @@ class TestInjector(unittest.IsolatedAsyncioTestCase):
         # skips the device alltogether, so no grab attempts fail
         self.assertEqual(self.failed, 0)
         self.assertEqual(devices, {})
+
+    def _add_multi_interface_aerox_fixtures(self):
+        """Create two event nodes of the same hardware device.
+
+        Mimics a SteelSeries Aerox 9 Wireless: the mapped button is emitted on
+        the "origin" node (event200), but that node does NOT advertise the
+        button in its static capabilities. A sibling node (event201) advertises
+        the button and would be picked by the device-type fallback instead.
+        """
+        info = evdev.device.DeviceInfo(7, 0x1038, 0x183A, 1)
+
+        origin = Fixture(
+            # event the button actually arrives on, but its capabilities do not
+            # list BTN_EXTRA (multi-interface devices under-report like this)
+            capabilities={evdev.ecodes.EV_KEY: [evdev.ecodes.KEY_LEFTCTRL]},
+            phys="usb-0000:09:00.3-2/input2",
+            info=info,
+            name="SteelSeries Aerox 9 Wireless sysrq kbd leds",
+            group_key="Aerox Test",
+            path="/dev/input/event200",
+        )
+        sibling = Fixture(
+            # a different node that *does* advertise BTN_EXTRA. Without honoring
+            # the origin_hash the injector would read from here instead.
+            capabilities={
+                evdev.ecodes.EV_KEY: [evdev.ecodes.BTN_EXTRA, evdev.ecodes.KEY_A]
+            },
+            phys="usb-0000:09:00.3-2/input3",
+            info=info,
+            name="SteelSeries Aerox 9 Wireless sysrq kbd leds 2",
+            group_key="Aerox Test",
+            path="/dev/input/event201",
+        )
+        fixtures.add_fixture(origin)
+        fixtures.add_fixture(sibling)
+
+        group = _Group(
+            paths=[origin.path, sibling.path],
+            names=[origin.name, sibling.name],
+            types=[DeviceType.KEYBOARD, DeviceType.KEYBOARD],
+            key="Aerox Test",
+        )
+        return group, origin, sibling
+
+    def test_reads_from_origin_hash_node_on_multi_interface_device(self):
+        # A button is emitted on the origin node, which does not advertise the
+        # button in its capabilities, while a sibling node does. The injector
+        # must honor the recorded origin_hash and start the read loop on the
+        # origin node rather than falling back to the sibling.
+        group, origin, sibling = self._add_multi_interface_aerox_fixtures()
+        origin_hash = origin.get_device_hash()
+        sibling_hash = sibling.get_device_hash()
+        self.assertNotEqual(origin_hash, sibling_hash)
+
+        preset = Preset()
+        preset.add(
+            Mapping.from_combination(
+                InputCombination(
+                    [
+                        InputConfig(
+                            type=EV_KEY,
+                            code=evdev.ecodes.BTN_EXTRA,
+                            origin_hash=origin_hash,
+                        )
+                    ]
+                ),
+                "keyboard",
+                "a",
+            )
+        )
+
+        self.initialize_injector(group, preset)
+        self.injector.context = Context(preset, {}, {}, self.mapping_parser)
+
+        # _update_preset must not overwrite the recorded origin_hash, even
+        # though the origin node does not advertise BTN_EXTRA.
+        mapping = list(self.injector.preset)[0]
+        self.assertEqual(
+            mapping.input_combination[0].origin_hash,
+            origin_hash,
+        )
+
+        # exactly one device gets grabbed (and therefore one read loop), and it
+        # is the origin node, not the sibling that merely advertises the code.
+        grabbed = self.injector._grab_devices()
+        self.assertEqual(len(grabbed), 1)
+        self.assertIn(origin.path, grabbed)
+        self.assertNotIn(sibling.path, grabbed)
+        self.assertEqual(grabbed[origin.path].path, origin.path)
+
+    def _add_hash_colliding_aerox_fixtures(self):
+        """Two devnodes of one device with identical capabilities and name.
+
+        get_device_hash is md5(capabilities + name), so these two distinct
+        /dev/input/eventXX nodes produce the *same* origin_hash - exactly like
+        the SteelSeries Aerox 9 Wireless, whose button is emitted on only one of
+        a pair of hash-identical nodes.
+        """
+        info = evdev.device.DeviceInfo(7, 0x1038, 0x183A, 1)
+        shared_caps = {evdev.ecodes.EV_KEY: [evdev.ecodes.KEY_8, evdev.ecodes.KEY_A]}
+
+        node_a = Fixture(
+            capabilities=shared_caps,
+            phys="usb-0000:09:00.3-2/input2",
+            info=info,
+            name="SteelSeries Aerox 9 Wireless",
+            group_key="Aerox Collision",
+            path="/dev/input/event210",
+        )
+        node_b = Fixture(
+            # identical capabilities AND name -> identical device hash
+            capabilities=shared_caps,
+            phys="usb-0000:09:00.3-2/input3",
+            info=info,
+            name="SteelSeries Aerox 9 Wireless",
+            group_key="Aerox Collision",
+            path="/dev/input/event211",
+        )
+        fixtures.add_fixture(node_a)
+        fixtures.add_fixture(node_b)
+
+        group = _Group(
+            paths=[node_a.path, node_b.path],
+            names=[node_a.name, node_b.name],
+            types=[DeviceType.KEYBOARD, DeviceType.KEYBOARD],
+            key="Aerox Collision",
+        )
+        return group, node_a, node_b
+
+    def test_grabs_all_nodes_sharing_an_origin_hash(self):
+        # Regression test for the SteelSeries Aerox 9: two devnodes share the
+        # same origin_hash. The button is emitted on only one of them, but we
+        # cannot know which in advance, so the injector must grab and start a
+        # read loop on BOTH. Previously the hash-keyed dict collapsed them into
+        # a single entry and the injector read from the wrong one.
+        group, node_a, node_b = self._add_hash_colliding_aerox_fixtures()
+        shared_hash = node_a.get_device_hash()
+        self.assertEqual(shared_hash, node_b.get_device_hash())
+
+        preset = Preset()
+        preset.add(
+            Mapping.from_combination(
+                InputCombination(
+                    [
+                        InputConfig(
+                            type=EV_KEY,
+                            code=evdev.ecodes.KEY_8,
+                            origin_hash=shared_hash,
+                        )
+                    ]
+                ),
+                "keyboard",
+                "a",
+            )
+        )
+
+        self.initialize_injector(group, preset)
+        self.injector.context = Context(preset, {}, {}, self.mapping_parser)
+
+        grabbed = self.injector._grab_devices()
+        # both hash-colliding nodes are grabbed (and get a read loop), keyed by
+        # their distinct paths rather than collapsed by the shared hash.
+        self.assertEqual(len(grabbed), 2)
+        self.assertIn(node_a.path, grabbed)
+        self.assertIn(node_b.path, grabbed)
 
     def test_get_udev_name(self):
         self.injector = Injector(


### PR DESCRIPTION
Fixes #1309

## Problem

On a device that exposes multiple `/dev/input/event*` nodes, the injector could grab and start its read loop on the *wrong* node, so the mapped button never produced any output. Observed with a **SteelSeries Aerox 9 Wireless**: the mapped button emits on one event node, but the injector read from a different one and nothing was injected. A single-interface device (e.g. a plain keyboard) was unaffected.

## Root cause

Device selection in `Injector` keyed everything on `get_device_hash()`, which is `md5(str(capabilities) + name)`. Two issues:

1. **Hash collisions.** That hash is **not unique per devnode**. Some hardware (the Aerox 9 among them) exposes several event nodes with byte-identical capabilities *and* name, so they produce the **same** `origin_hash`. `_find_input_device` built `devices_by_hash = {hash: device}` and `_grab_devices` returned `{hash: device}` — both collapse colliding nodes to a single entry, so only one twin was grabbed/read. If the event is emitted on the other twin, it is silently missed.

2. **Over-strict capability gate.** `_find_input_device` additionally required the mapped `code` to be present in the node's advertised capabilities. Nodes that emit codes outside their static capabilities had their valid `origin_hash` discarded, and `_update_preset` then overwrote it via the device-type fallback — pointing the injector at a different node.

## Fix

- Replace `_find_input_device` with `_find_input_devices`, returning **every** devnode whose hash matches the `origin_hash` (and dropping the capability gate — a matching hash already guarantees identical capabilities to recording time, so the recorded node is authoritative).
- Key `_grab_devices` by **path** instead of hash, so colliding nodes are all grabbed.
- Start **one read loop per devnode** in `run()`. Forwarding devices stay keyed by hash (one per unique hash; colliding nodes are interchangeable for forwarding).

When `origin_hash` is absent or matches nothing (old presets / configs moved between machines), behavior is unchanged: the existing `_find_input_device_fallback` still runs.

## Tests

Adds two regression tests in `tests/unit/test_injector.py`:
- `test_grabs_all_nodes_sharing_an_origin_hash` — two hash-identical nodes are both grabbed (the Aerox 9 case).
- `test_reads_from_origin_hash_node_on_multi_interface_device` — a node that under-reports the mapped code in its capabilities is still honored, not overwritten by the fallback.

Both fail on `main` and pass with the fix. `test_injector.py`, `test_event_pipeline`, `test_groups`, `test_event_reader` and `test_context` pass (the two pre-existing subprocess-spawning failures in `test_injector` fail identically on `main` and are unrelated to this change).

Verified live on the affected SteelSeries Aerox 9 Wireless: the mapped button now works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)