### PR TITLE
Relax timing in test_reader for github workflows

### DIFF
--- a/tests/unit/test_reader.py
+++ b/tests/unit/test_reader.py
@@ -212,7 +212,7 @@ class TestReaderMultiprocessing(unittest.TestCase):
             target=start_reader_service
         )
         self.reader_service_process.start()
-        time.sleep(0.1)
+        time.sleep(GITHUB_WORKFLOW_TIMEOUT_SLACK)
 
     def test_reading(self):
         l1 = Listener()
@@ -230,7 +230,7 @@ class TestReaderMultiprocessing(unittest.TestCase):
 
         # relative axis events should be released automagically after 0.3s
         push_events(fixtures.foo_device_2_mouse, [InputEvent.rel(REL_X, 5)])
-        time.sleep(0.1)
+        time.sleep(GITHUB_WORKFLOW_TIMEOUT_SLACK)
         # read all pending events. Having a glib mainloop would be better,
         # as it would call read automatically periodically
         self.reader_client._read()
@@ -290,7 +290,7 @@ class TestReaderMultiprocessing(unittest.TestCase):
         self.reader_client.start_recorder()
 
         push_events(fixtures.foo_device_2_mouse, [InputEvent.rel(REL_X, -5)])
-        time.sleep(0.1)
+        time.sleep(GITHUB_WORKFLOW_TIMEOUT_SLACK)
         self.reader_client._read()
 
         self.assertEqual(
@@ -324,7 +324,7 @@ class TestReaderMultiprocessing(unittest.TestCase):
         self.reader_client.start_recorder()
 
         push_events(fixtures.foo_device_2_mouse, [InputEvent.rel(REL_X, -1)])
-        time.sleep(0.1)
+        time.sleep(GITHUB_WORKFLOW_TIMEOUT_SLACK)
         self.reader_client._read()
         self.assertEqual(0, len(l1.calls))
 
@@ -389,11 +389,11 @@ class TestReaderMultiprocessing(unittest.TestCase):
         self.reader_client.start_recorder()
 
         push_events(fixtures.foo_device_2_keyboard, [InputEvent.key(KEY_A, 1)])
-        time.sleep(0.1)
+        time.sleep(GITHUB_WORKFLOW_TIMEOUT_SLACK)
         self.reader_client._read()
         # the duplicate event should be ignored
         push_events(fixtures.foo_device_2_keyboard, [InputEvent.key(KEY_A, 1)])
-        time.sleep(0.1)
+        time.sleep(GITHUB_WORKFLOW_TIMEOUT_SLACK)
         self.reader_client._read()
 
         self.assertEqual(
@@ -427,7 +427,7 @@ class TestReaderMultiprocessing(unittest.TestCase):
             fixtures.foo_device_2_gamepad,
             [InputEvent.abs(ABS_X, int(fixtures.foo_device_2_gamepad.max_abs * 0.4))],
         )
-        time.sleep(0.1)
+        time.sleep(GITHUB_WORKFLOW_TIMEOUT_SLACK)
         self.reader_client._read()
         self.assertEqual(
             [
@@ -453,7 +453,7 @@ class TestReaderMultiprocessing(unittest.TestCase):
             fixtures.foo_device_2_gamepad,
             [InputEvent.abs(ABS_X, int(fixtures.foo_device_2_gamepad.max_abs * 0.2))],
         )
-        time.sleep(0.1)
+        time.sleep(GITHUB_WORKFLOW_TIMEOUT_SLACK)
         self.reader_client._read()
         self.assertEqual(
             [
@@ -482,14 +482,14 @@ class TestReaderMultiprocessing(unittest.TestCase):
         self.reader_client.start_recorder()
 
         push_event(fixtures.foo_device_2_keyboard, InputEvent.key(KEY_A, 1))
-        time.sleep(0.1)
+        time.sleep(0.05)
         push_event(
             fixtures.foo_device_2_gamepad,
             InputEvent.abs(ABS_X, int(fixtures.foo_device_2_gamepad.max_abs * 0.4)),
         )
-        time.sleep(0.1)
+        time.sleep(0.05)
         push_event(fixtures.foo_device_2_keyboard, InputEvent.key(KEY_COMMA, 1))
-        time.sleep(0.1)
+        time.sleep(0.05)
         push_events(
             fixtures.foo_device_2_gamepad,
             [
@@ -497,7 +497,7 @@ class TestReaderMultiprocessing(unittest.TestCase):
                 InputEvent.abs(ABS_X, int(fixtures.foo_device_2_gamepad.min_abs * 0.4)),
             ],
         )
-        time.sleep(0.1)
+        time.sleep(GITHUB_WORKFLOW_TIMEOUT_SLACK)
         self.reader_client._read()
         self.assertEqual(
             [
@@ -601,7 +601,7 @@ class TestReaderMultiprocessing(unittest.TestCase):
         self.create_reader_service()
         self.reader_client.set_group(self.groups.find(key="Foo Device 2"))
         self.reader_client.start_recorder()
-        time.sleep(0.1)
+        time.sleep(GITHUB_WORKFLOW_TIMEOUT_SLACK)
         self.reader_client._read()
         self.assertEqual(
             l1.calls[0].combination,
@@ -617,7 +617,7 @@ class TestReaderMultiprocessing(unittest.TestCase):
         )
 
         self.reader_client.set_group(self.groups.find(name="Bar Device"))
-        time.sleep(0.1)
+        time.sleep(GITHUB_WORKFLOW_TIMEOUT_SLACK)
         self.reader_client._read()
 
         # we did not get the event from the "Bar Device" because the group change
@@ -626,7 +626,7 @@ class TestReaderMultiprocessing(unittest.TestCase):
 
         self.reader_client.start_recorder()
         push_events(fixtures.bar_device, [InputEvent.key(2, 1)])
-        time.sleep(0.1)
+        time.sleep(GITHUB_WORKFLOW_TIMEOUT_SLACK)
         self.reader_client._read()
         self.assertEqual(
             l1.calls[1].combination,
@@ -677,7 +677,7 @@ class TestReaderMultiprocessing(unittest.TestCase):
             fixtures.foo_device_2_gamepad,
             [new_event(EV_ABS, ABS_HAT0X, -1, 10002.1234)],
         )
-        time.sleep(0.1)
+        time.sleep(GITHUB_WORKFLOW_TIMEOUT_SLACK)
         # but it makes it look for new devices because maybe its list of
         # self.groups is not up-to-date
         self.assertTrue(pipe[0].poll())
@@ -727,7 +727,7 @@ class TestReaderMultiprocessing(unittest.TestCase):
         self.create_reader_service()
         self.reader_client.set_group(self.groups.find(key="Foo Device 2"))
         self.reader_client.start_recorder()
-        time.sleep(0.1)
+        time.sleep(GITHUB_WORKFLOW_TIMEOUT_SLACK)
         self.reader_client._read()
         self.assertEqual(
             l1.calls[-1].combination,
@@ -784,7 +784,7 @@ class TestReaderMultiprocessing(unittest.TestCase):
         self.create_reader_service()
         self.reader_client.set_group(self.groups.find(key="Foo Device 2"))
         self.reader_client.start_recorder()
-        time.sleep(0.1)
+        time.sleep(GITHUB_WORKFLOW_TIMEOUT_SLACK)
         self.reader_client._read()
         self.assertEqual(
             l1.calls[-1].combination,
@@ -863,7 +863,8 @@ class TestReaderMultiprocessing(unittest.TestCase):
         self.create_reader_service()
         self.reader_client.groups.set_groups([])
 
-        time.sleep(0.1)  # let the reader-service send the groups
+        # let the reader-service send the groups
+        time.sleep(GITHUB_WORKFLOW_TIMEOUT_SLACK)
         # read stuff from the reader-service, which includes the devices
         self.assertEqual("[]", self.reader_client.groups.dumps())
         self.reader_client._read()


### PR DESCRIPTION
test_reader tests keep failing randomly in github, while working fine locally. I don't think this has always been an issue, do workflow vms have less resources now/currently?