### PR TITLE
Bring pyproject.toml up to standards

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,8 @@ description = "A tool to change the mapping of your input device buttons"
 authors = [
     { name = "Sezanzeb", email = "b8x45ygc9@mozmail.com" },
 ]
-license = { file = "LICENSE" }
+license = "GPL-3.0-or-later"
+license-files = ["LICENSE"]
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
@@ -30,3 +31,7 @@ Homepage = "https://github.com/sezanzeb/input-remapper"
 ignore = ["E402"]
 # Lots of unused imports in
 exclude = ["install/check_dependencies.py"]
+
+[build-system]
+requires = ["setuptools >= 77.0.3"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Hello,

While investigating a build failure in Fedora, I discovered that a build backend must be specified in the pyproject.toml file. Fedora tools look for that and when they do not find it, they revert to thinking that it's a legacy package and start looking for a setup.py file. See here: https://packaging.python.org/en/latest/tutorials/packaging-projects/#choosing-a-build-backend

As for the version number, I just reused the one from their example, feel free to change it to something else or to another build system entirely.


I've also noticed a warning that accepting the current license declaration will start failing next year, so I thought I'd take care of that as well. This is documented in the following [paragraph](https://packaging.python.org/en/latest/tutorials/packaging-projects/#configuring-metadata).