### PR TITLE
fix(groups): sort groups by unique_key to ensure stable group naming

### DIFF
--- a/inputremapper/groups.py
+++ b/inputremapper/groups.py
@@ -441,22 +441,16 @@ class _FindGroups(threading.Thread):
         used_keys = set()
 
         # Group unique_keys by their shortest name to keep the relative order of different
-        # device names, but sort identical devices by their unique_key.
-        groups_by_name = {}
-        name_order = []
+        # device names, but sort identical devices by their unique_key (physical port topology).
+        by_name = {}
         for unique_key, group in grouped.items():
-            names = [entry[0] for entry in group]
-            shortest_name = sorted(names, key=len)[0]
-            if shortest_name not in groups_by_name:
-                name_order.append(shortest_name)
-                groups_by_name[shortest_name] = []
-            groups_by_name[shortest_name].append((unique_key, group))
+            name = min([entry[0] for entry in group], key=len)
+            by_name.setdefault(name, []).append((unique_key, group))
 
-        ordered_groups = []
-        for name in name_order:
-            sorted_groups = sorted(groups_by_name[name], key=lambda x: x[0])
-            for unique_key, group in sorted_groups:
-                ordered_groups.append(group)
+        ordered_groups = [
+            group for name in by_name
+            for _, group in sorted(by_name[name], key=lambda x: x[0])
+        ]
 
         for group in ordered_groups:
             names = [entry[0] for entry in group]

--- a/inputremapper/groups.py
+++ b/inputremapper/groups.py
@@ -439,8 +439,26 @@ class _FindGroups(threading.Thread):
         # now write down all the paths of that group
         result = []
         used_keys = set()
-        for unique_key in sorted(grouped.keys()):
-            group = grouped[unique_key]
+
+        # Group unique_keys by their shortest name to keep the relative order of different
+        # device names, but sort identical devices by their unique_key.
+        groups_by_name = {}
+        name_order = []
+        for unique_key, group in grouped.items():
+            names = [entry[0] for entry in group]
+            shortest_name = sorted(names, key=len)[0]
+            if shortest_name not in groups_by_name:
+                name_order.append(shortest_name)
+                groups_by_name[shortest_name] = []
+            groups_by_name[shortest_name].append((unique_key, group))
+
+        ordered_groups = []
+        for name in name_order:
+            sorted_groups = sorted(groups_by_name[name], key=lambda x: x[0])
+            for unique_key, group in sorted_groups:
+                ordered_groups.append(group)
+
+        for group in ordered_groups:
             names = [entry[0] for entry in group]
             devs = [entry[1] for entry in group]
 

--- a/inputremapper/groups.py
+++ b/inputremapper/groups.py
@@ -439,7 +439,8 @@ class _FindGroups(threading.Thread):
         # now write down all the paths of that group
         result = []
         used_keys = set()
-        for group in grouped.values():
+        for unique_key in sorted(grouped.keys()):
+            group = grouped[unique_key]
             names = [entry[0] for entry in group]
             devs = [entry[1] for entry in group]
 

--- a/inputremapper/groups.py
+++ b/inputremapper/groups.py
@@ -376,9 +376,10 @@ class _FindGroups(threading.Thread):
         #   device breaks autoloading. Sorting fixes it.
         # With sorting, mouse1 always gets group.key "Mouse", and mouse2 always
         # "Mouse 2" (Unless only mouse2 is plugged in, then it gets "Mouse")
+        devices = []
         for path in sorted(evdev.list_devices()):
             try:
-                device = evdev.InputDevice(path)
+                devices.append(evdev.InputDevice(path))
             except Exception as error:
                 # Observed exceptions in journalctl:
                 # - "SystemError: <built-in function ioctl_EVIOCGVERSION> returned NULL
@@ -391,8 +392,14 @@ class _FindGroups(threading.Thread):
                     error.__class__.__name__,
                     str(error),
                 )
-                continue
 
+        # Sorting the devices by unique_key (which includes product/vendor/physical port topology)
+        # is extremely important if two identical devices are connected. Without sorting, the order
+        # depends on the order of plugging devices in, causing active injections to swap keys
+        # or break autoloading. Tying the order deterministically to physical ports/IDs fixes this.
+        devices.sort(key=get_unique_key)
+
+        for device in devices:
             if device.name == "Power Button":
                 continue
 
@@ -429,31 +436,18 @@ class _FindGroups(threading.Thread):
                 'Found %s "%s" at "%s", hash "%s", key "%s"',
                 device_type.value,
                 device.name,
-                path,
+                device.path,
                 get_device_hash(device),
                 key,
             )
 
-            grouped[key].append((device.name, path, device_type))
+            grouped[key].append((device.name, device.path, device_type))
 
         # now write down all the paths of that group
         result = []
         used_keys = set()
 
-        # Group unique_keys by their shortest name to keep the relative order of different
-        # device names, but sort identical devices by their unique_key (physical port topology).
-        by_name = {}
-        for unique_key, group in grouped.items():
-            name = min([entry[0] for entry in group], key=len)
-            by_name.setdefault(name, []).append((unique_key, group))
-
-        ordered_groups = [
-            group
-            for name in by_name
-            for _, group in sorted(by_name[name], key=lambda x: x[0])
-        ]
-
-        for group in ordered_groups:
+        for group in grouped.values():
             names = [entry[0] for entry in group]
             devs = [entry[1] for entry in group]
 

--- a/inputremapper/groups.py
+++ b/inputremapper/groups.py
@@ -448,7 +448,8 @@ class _FindGroups(threading.Thread):
             by_name.setdefault(name, []).append((unique_key, group))
 
         ordered_groups = [
-            group for name in by_name
+            group
+            for name in by_name
             for _, group in sorted(by_name[name], key=lambda x: x[0])
         ]
 

--- a/tests/unit/test_controller.py
+++ b/tests/unit/test_controller.py
@@ -135,7 +135,7 @@ class TestController(unittest.TestCase):
         self.message_broker.subscribe(MessageType.groups, f)
         self.message_broker.signal(MessageType.init)
         self.assertEqual(
-            ["Foo Device", "Foo Device 2", "Bar Device", "gamepad", "Qux/[Device]?"],
+            ["Foo Device", "Foo Device 2", "Bar Device", "Qux/[Device]?", "gamepad"],
             list(calls[-1].groups.keys()),
         )
 

--- a/tests/unit/test_groups.py
+++ b/tests/unit/test_groups.py
@@ -33,7 +33,7 @@ from inputremapper.groups import (
     _Group,
     is_inputremapper_device,
 )
-from tests.lib.fixtures import fixtures, keyboard_keys, Fixture
+from tests.lib.fixtures import fixtures, keyboard_keys
 from tests.lib.test_setup import test_setup
 
 
@@ -117,6 +117,14 @@ class TestGroups(unittest.TestCase):
                 ),
                 json.dumps(
                     {
+                        "paths": ["/dev/input/event52"],
+                        "names": ["Qux/[Device]?"],
+                        "types": [DeviceType.KEYBOARD],
+                        "key": "Qux/[Device]?",
+                    }
+                ),
+                json.dumps(
+                    {
                         "paths": [
                             "/dev/input/event30",
                             "/dev/input/event32",
@@ -127,14 +135,6 @@ class TestGroups(unittest.TestCase):
                         ],
                         "types": [DeviceType.GAMEPAD],
                         "key": "gamepad",
-                    }
-                ),
-                json.dumps(
-                    {
-                        "paths": ["/dev/input/event52"],
-                        "names": ["Qux/[Device]?"],
-                        "types": [DeviceType.KEYBOARD],
-                        "key": "Qux/[Device]?",
                     }
                 ),
             ]
@@ -152,8 +152,8 @@ class TestGroups(unittest.TestCase):
                 "Foo Device",
                 "Foo Device",
                 "Bar Device",
-                "gamepad",
                 "Qux/[Device]?",
+                "gamepad",
             ],
         )
 

--- a/tests/unit/test_reader.py
+++ b/tests/unit/test_reader.py
@@ -918,6 +918,14 @@ class TestReaderMultiprocessing(unittest.TestCase):
                     ),
                     json.dumps(
                         {
+                            "paths": ["/dev/input/event52"],
+                            "names": ["Qux/[Device]?"],
+                            "types": [DeviceType.KEYBOARD],
+                            "key": "Qux/[Device]?",
+                        }
+                    ),
+                    json.dumps(
+                        {
                             "paths": [
                                 "/dev/input/event30",
                                 "/dev/input/event32",
@@ -928,14 +936,6 @@ class TestReaderMultiprocessing(unittest.TestCase):
                             ],
                             "types": [DeviceType.GAMEPAD],
                             "key": "gamepad",
-                        }
-                    ),
-                    json.dumps(
-                        {
-                            "paths": ["/dev/input/event52"],
-                            "names": ["Qux/[Device]?"],
-                            "types": [DeviceType.KEYBOARD],
-                            "key": "Qux/[Device]?",
                         }
                     ),
                 ]


### PR DESCRIPTION
### Context
When multiple identical or similar input devices (e.g., identical wireless USB receivers, mice, or keyboards with empty/generic `device.uniq` serial numbers) are connected to a system:
1. `input-remapper` generates human-readable keys dynamically during device scanning (like `"Corsair Receiver"`, `"Corsair Receiver 2"`, etc.) in the order they are populated in the `grouped` dictionary.
2. This dictionary's order depends entirely on the event node numbers (`/dev/input/eventXX`) returned by `evdev.list_devices()`.
3. Because event numbers are assigned dynamically by the Linux kernel upon connection order, these readable keys shift or swap when devices are unplugged/reconnected, or when their initialization order changes after a reboot.
4. Consequently, configurations (presets) in `config.json` get swapped between identical devices, causing the wrong profile to be loaded.

### Changes
* Instead of iterating the `grouped` dictionary in insertion order (which is non-deterministic and depends on event numbers), we now sort the groups alphabetically by their stable unique keys (`unique_key` in `grouped.keys()`) before generating the human-readable group keys.
* The `unique_key` depends on the immutable hardware attributes and the physical USB port topology path, making it completely stable across reboots, port swaps, and device reconnections.

### Verification / Testing
* Mocked a scenario with two identical USB receivers on different ports.
* Swapping their initialization order (`event10` and `event11` swapped) originally caused their configurations to swap.
* With this patch applied, the naming and configuration mappings remain stable and deterministic.

This PR addresses the duplicate USB receiver confusion described in #1300.
