### PR TITLE
Add Global toggle support

### DIFF
--- a/data/input-remapper.glade
+++ b/data/input-remapper.glade
@@ -1305,16 +1305,40 @@ Only relevant when mapping relative inputs (e.g. mouse) to absolute outputs (e.g
           </object>
         </child>
         <child>
-          <object class="GtkButton" id="about">
+          <object class="GtkBox">
             <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="receives-default">True</property>
-            <property name="tooltip-text" translatable="yes">Help</property>
-            <property name="halign">end</property>
-            <property name="valign">center</property>
-            <property name="image">about-icon</property>
-            <property name="always-show-image">True</property>
-            <signal name="clicked" handler="on_gtk_about_clicked" swapped="no"/>
+            <property name="can-focus">False</property>
+            <property name="spacing">6</property>
+            <child>
+              <object class="GtkToggleButton" id="toggle-suspend">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="label">Suspend</property>
+                <property name="always-show-image">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="about">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="tooltip-text" translatable="yes">Help</property>
+                <property name="halign">end</property>
+                <property name="valign">center</property>
+                <property name="image">about-icon</property>
+                <property name="always-show-image">True</property>
+                <signal name="clicked" handler="on_gtk_about_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="pack-type">end</property>

--- a/inputremapper/bin/input_remapper_control.py
+++ b/inputremapper/bin/input_remapper_control.py
@@ -44,6 +44,9 @@ class Commands(Enum):
     START = "start"
     STOP = "stop"
     STOP_ALL = "stop-all"
+    SUSPEND = "suspend"
+    RESUME = "resume"
+    TOGGLE_SUSPEND = "toggle-suspend"
     HELLO = "hello"
     QUIT = "quit"
 
@@ -176,6 +179,16 @@ class InputRemapperControlBin:
 
         if command == Commands.STOP_ALL.value:
             self.daemon.stop_all()
+
+        if command == Commands.SUSPEND.value:
+            self.daemon.set_suspended(True)
+
+        if command == Commands.RESUME.value:
+            self.daemon.set_suspended(False)
+
+        if command == Commands.TOGGLE_SUSPEND.value:
+            suspended = self.daemon.is_suspended()
+            self.daemon.set_suspended(not suspended)
 
         if command == Commands.HELLO.value:
             self._hello()

--- a/inputremapper/daemon.py
+++ b/inputremapper/daemon.py
@@ -121,7 +121,13 @@ class DaemonProxy(Protocol):  # pragma: no cover
 
     def start_injecting(self, group_key: str, preset: str) -> bool: ...
 
+    def get_running_preset(self, group_key: str) -> str: ...
+
     def stop_all(self) -> None: ...
+
+    def set_suspended(self, suspended: bool) -> None: ...
+
+    def is_suspended(self) -> bool: ...
 
     def set_config_dir(self, config_dir: str) -> None: ...
 
@@ -163,6 +169,16 @@ class Daemon:
                 </method>
                 <method name='stop_all'>
                 </method>
+                <method name='set_suspended'>
+                    <arg type='b' name='suspended' direction='in'/>
+                </method>
+                <method name='is_suspended'>
+                    <arg type='b' name='response' direction='out'/>
+                </method>
+                <method name='get_running_preset'>
+                    <arg type='s' name='group_key' direction='in'/>
+                    <arg type='s' name='response' direction='out'/>
+                </method>
                 <method name='set_config_dir'>
                     <arg type='s' name='config_dir' direction='in'/>
                 </method>
@@ -195,6 +211,8 @@ class Daemon:
         self.mapping_parser = mapping_parser
 
         self.injectors: Dict[str, Injector] = {}
+        self.suspended = False
+        self.suspended_presets: Dict[str, str] = {}
 
         self.config_dir = None
 
@@ -312,6 +330,9 @@ class Daemon:
 
     def stop_injecting(self, group_key: str) -> None:
         """Stop injecting the preset mappings for a single device."""
+        if group_key in self.suspended_presets:
+            del self.suspended_presets[group_key]
+
         if self.injectors.get(group_key) is None:
             logger.debug(
                 'Tried to stop injector, but none is running for group "%s"',
@@ -326,6 +347,59 @@ class Daemon:
         """Get the injectors state."""
         injector = self.injectors.get(group_key)
         return injector.get_state() if injector else InjectorState.UNKNOWN
+
+    def get_running_preset(self, group_key: str) -> str:
+        """Get the running preset name for a group."""
+        injector = self.injectors.get(group_key)
+        if injector and injector.is_alive():
+            return injector.preset.name or ""
+        return ""
+
+    def is_suspended(self) -> bool:
+        """Check if remapping is globally suspended."""
+        return self.suspended
+
+    def _suspend_injection(self, group_key: str, injector: Injector) -> None:
+        """Suspend a single active injector."""
+        # Only suspend injectors that are currently active (matching InjectorStateMessage.active())
+        if not injector or injector.get_state() not in (
+            InjectorState.STARTING,
+            InjectorState.RUNNING,
+        ):
+            return
+
+        preset_name = injector.preset.name
+        if preset_name:
+            self.suspended_presets[group_key] = preset_name
+        else:
+            logger.error(
+                "Suspending injector for %s without a preset name. It will not be resumed automatically.",
+                group_key,
+            )
+        try:
+            injector.stop_injecting()
+        except Exception as e:
+            logger.error(
+                "Failed to stop injector for %s during suspend: %s",
+                group_key,
+                e,
+            )
+
+    def set_suspended(self, suspended: bool) -> None:
+        """Globally suspend or resume all remappings."""
+        if self.suspended == suspended:
+            return
+        self.suspended = suspended
+        if self.suspended:
+            logger.info("Suspending all active remappings")
+            for group_key, injector in list(self.injectors.items()):
+                self._suspend_injection(group_key, injector)
+        else:
+            logger.info("Resuming all suspended remappings")
+            to_resume = list(self.suspended_presets.items())
+            self.suspended_presets.clear()
+            for group_key, preset_name in to_resume:
+                self._start_injecting_internal(group_key, preset_name)
 
     def set_config_dir(self, config_dir: str) -> None:
         """All future operations will use this config dir.
@@ -449,6 +523,18 @@ class Daemon:
         preset_name
             The name of the preset
         """
+        if self.suspended:
+            self.suspended_presets[group_key] = preset_name
+            logger.info(
+                'Queued injection request for "%s" with preset "%s" (suspended)',
+                group_key,
+                preset_name,
+            )
+            return True
+
+        return self._start_injecting_internal(group_key, preset_name)
+
+    def _start_injecting_internal(self, group_key: str, preset_name: str) -> bool:
         logger.info('Request to start injecting for "%s"', group_key)
 
         self.refresh(group_key)

--- a/inputremapper/gui/components/suspend_button.py
+++ b/inputremapper/gui/components/suspend_button.py
@@ -57,7 +57,7 @@ class SuspendButton:
     def _update_global_switch(self, *_args) -> None:
         is_suspended = True
         try:
-            is_suspended = self.controller.data_manager._daemon.is_suspended()
+            is_suspended = self.controller.data_manager.is_suspended()
         except Exception as e:
             logger.error("Failed to query suspended state from daemon: %s", e)
 

--- a/inputremapper/gui/components/suspend_button.py
+++ b/inputremapper/gui/components/suspend_button.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+# input-remapper - GUI for device specific keyboard mappings
+# Copyright (C) 2025 sezanzeb <b8x45ygc9@mozmail.com>
+#
+# This file is part of input-remapper.
+#
+# input-remapper is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# input-remapper is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with input-remapper.  If not, see <https://www.gnu.org/licenses/>.
+
+
+"""Components used in multiple places."""
+
+from __future__ import annotations
+
+from gi.repository import Gtk
+
+from inputremapper.gui.controller import Controller
+from inputremapper.gui.messages.message_broker import (
+    MessageBroker,
+    MessageType,
+)
+from inputremapper.gui.utils import HandlerDisabled
+from inputremapper.gui.gettext import _
+from inputremapper.logging.logger import logger
+
+
+class SuspendButton:
+    """A button that suspends all injections or resumes them."""
+
+    def __init__(
+        self,
+        message_broker: MessageBroker,
+        controller: Controller,
+        toggle_button: Gtk.ToggleButton,
+    ):
+        self._message_broker = message_broker
+        self._gui = toggle_button
+        self.controller = controller
+
+        self.global_switch_handler = self._gui.connect(
+            "toggled",
+            self._on_global_switch_toggled,
+        )
+
+        # Initialize the toggled state and tooltip
+        self._update_global_switch()
+
+    def _update_global_switch(self, *_args) -> None:
+        is_suspended = True
+        try:
+            is_suspended = self.controller.data_manager._daemon.is_suspended()
+        except Exception as e:
+            logger.error("Failed to query suspended state from daemon: %s", e)
+
+        resume_term, suspend_term = self._get_button_text_translations()
+
+        if is_suspended:
+            self._gui.set_tooltip_text(_("Enable all suspended presets"))
+            icon = Gtk.Image.new_from_icon_name(
+                "media-playback-start",
+                Gtk.IconSize.BUTTON,
+            )
+            # Add a trailing whitespace to make the buttons width fluctuate less
+            self._gui.set_label(resume_term)
+        else:
+            self._gui.set_tooltip_text(_("Temporarily pause all active presets"))
+            icon = Gtk.Image.new_from_icon_name(
+                "media-playback-pause",
+                Gtk.IconSize.BUTTON,
+            )
+            self._gui.set_label(suspend_term)
+
+        icon.set_margin_right(2)
+        self._gui.set_image(icon)
+
+        with HandlerDisabled(self._gui, self._on_global_switch_toggled):
+            self._gui.set_active(is_suspended)
+
+    def _on_global_switch_toggled(self, widget) -> bool:
+        state = widget.get_active()
+        try:
+            self.controller.data_manager.set_suspended(state)
+        except Exception as e:
+            logger.error("Failed to toggle global suspend state: %s", e)
+        self._update_global_switch()
+        return False
+
+    def _get_button_text_translations(self) -> tuple[str, str]:
+        resume_term = _("Resume")
+        suspend_term = _("Suspend")
+
+        # To make their width similar, add trialing whitespaces
+        length = max(len(resume_term), len(suspend_term))
+        return (
+            resume_term.ljust(length),
+            suspend_term.ljust(length),
+        )

--- a/inputremapper/gui/components/suspend_button.py
+++ b/inputremapper/gui/components/suspend_button.py
@@ -27,7 +27,6 @@ from gi.repository import Gtk
 from inputremapper.gui.controller import Controller
 from inputremapper.gui.messages.message_broker import (
     MessageBroker,
-    MessageType,
 )
 from inputremapper.gui.utils import HandlerDisabled
 from inputremapper.gui.gettext import _

--- a/inputremapper/gui/data_manager.py
+++ b/inputremapper/gui/data_manager.py
@@ -610,3 +610,6 @@ class DataManager:
 
     def set_suspended(self, state: bool) -> None:
         self._daemon.set_suspended(state)
+
+    def is_suspended(self) -> bool:
+        return self._daemon.is_suspended()

--- a/inputremapper/gui/data_manager.py
+++ b/inputremapper/gui/data_manager.py
@@ -607,3 +607,6 @@ class DataManager:
             return True
 
         GLib.timeout_add(100, do)
+
+    def set_suspended(self, state: bool) -> None:
+        self._daemon.set_suspended(state)

--- a/inputremapper/gui/user_interface.py
+++ b/inputremapper/gui/user_interface.py
@@ -110,6 +110,7 @@ class UserInterface:
         self._create_components()
         self._connect_gtk_signals()
         self._connect_message_listener()
+        self._init_global_switch()
 
         self.window.show()
         # hide everything until stuff is populated
@@ -415,3 +416,59 @@ class UserInterface:
     def on_gtk_preset_name_input_return(self, _, event: Gdk.EventKey):
         if event.keyval == Gdk.KEY_Return:
             self.on_gtk_rename_clicked()
+
+    def _init_global_switch(self) -> None:
+        headerbar = self.window.get_titlebar()
+        if not headerbar:
+            return
+
+        box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        self.global_label = Gtk.Label(label=_("Suspend"))
+
+        self.global_switch = Gtk.Switch()
+        self.global_switch.set_valign(Gtk.Align.CENTER)
+
+        box.pack_start(self.global_label, False, False, 0)
+        box.pack_start(self.global_switch, False, False, 0)
+        box.show_all()
+        headerbar.pack_end(box)
+
+        self.global_switch_handler = self.global_switch.connect(
+            "state-set", self._on_global_switch_toggled
+        )
+
+        self.message_broker.subscribe(
+            MessageType.injector_state, self._update_global_switch
+        )
+        self.message_broker.subscribe(MessageType.preset, self._update_global_switch)
+        self.message_broker.subscribe(MessageType.group, self._update_global_switch)
+
+        self._update_global_switch()
+
+    def _update_global_switch(self, *_args) -> None:
+        if not hasattr(self, "global_switch") or not self.global_switch:
+            return
+
+        is_suspended = True
+        try:
+            is_suspended = self.controller.data_manager._daemon.is_suspended()
+        except Exception as e:
+            logger.error("Failed to query suspended state from daemon: %s", e)
+
+        if is_suspended:
+            self.global_switch.set_tooltip_text(_("Enable all active presets"))
+        else:
+            self.global_switch.set_tooltip_text(_("Pause all active presets"))
+
+        from inputremapper.gui.utils import HandlerDisabled
+
+        with HandlerDisabled(self.global_switch, self._on_global_switch_toggled):
+            self.global_switch.set_active(is_suspended)
+
+    def _on_global_switch_toggled(self, widget, state: bool) -> bool:
+        try:
+            self.controller.data_manager._daemon.set_suspended(state)
+        except Exception as e:
+            logger.error("Failed to toggle global suspend state: %s", e)
+        self._update_global_switch()
+        return False

--- a/inputremapper/gui/user_interface.py
+++ b/inputremapper/gui/user_interface.py
@@ -19,6 +19,7 @@
 
 
 """User Interface."""
+
 from typing import Dict, Callable
 
 from gi.repository import Gtk, GtkSource, Gdk, GObject
@@ -51,6 +52,7 @@ from inputremapper.gui.components.editor import (
 )
 from inputremapper.gui.components.main import Stack, StatusBar
 from inputremapper.gui.components.presets import PresetSelection
+from inputremapper.gui.components.suspend_button import SuspendButton
 from inputremapper.gui.controller import Controller
 from inputremapper.gui.gettext import _
 from inputremapper.gui.messages.message_broker import (
@@ -110,7 +112,6 @@ class UserInterface:
         self._create_components()
         self._connect_gtk_signals()
         self._connect_message_listener()
-        self._init_global_switch()
 
         self.window.show()
         # hide everything until stuff is populated
@@ -220,6 +221,12 @@ class UserInterface:
             message_broker,
             self.get("delete-mapping"),
             require_recorded_input=False,
+        )
+
+        SuspendButton(
+            message_broker,
+            controller,
+            self.get("toggle-suspend"),
         )
 
         # code editor and autocompletion
@@ -416,59 +423,3 @@ class UserInterface:
     def on_gtk_preset_name_input_return(self, _, event: Gdk.EventKey):
         if event.keyval == Gdk.KEY_Return:
             self.on_gtk_rename_clicked()
-
-    def _init_global_switch(self) -> None:
-        headerbar = self.window.get_titlebar()
-        if not headerbar:
-            return
-
-        box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
-        self.global_label = Gtk.Label(label=_("Suspend"))
-
-        self.global_switch = Gtk.Switch()
-        self.global_switch.set_valign(Gtk.Align.CENTER)
-
-        box.pack_start(self.global_label, False, False, 0)
-        box.pack_start(self.global_switch, False, False, 0)
-        box.show_all()
-        headerbar.pack_end(box)
-
-        self.global_switch_handler = self.global_switch.connect(
-            "state-set", self._on_global_switch_toggled
-        )
-
-        self.message_broker.subscribe(
-            MessageType.injector_state, self._update_global_switch
-        )
-        self.message_broker.subscribe(MessageType.preset, self._update_global_switch)
-        self.message_broker.subscribe(MessageType.group, self._update_global_switch)
-
-        self._update_global_switch()
-
-    def _update_global_switch(self, *_args) -> None:
-        if not hasattr(self, "global_switch") or not self.global_switch:
-            return
-
-        is_suspended = True
-        try:
-            is_suspended = self.controller.data_manager._daemon.is_suspended()
-        except Exception as e:
-            logger.error("Failed to query suspended state from daemon: %s", e)
-
-        if is_suspended:
-            self.global_switch.set_tooltip_text(_("Enable all active presets"))
-        else:
-            self.global_switch.set_tooltip_text(_("Pause all active presets"))
-
-        from inputremapper.gui.utils import HandlerDisabled
-
-        with HandlerDisabled(self.global_switch, self._on_global_switch_toggled):
-            self.global_switch.set_active(is_suspended)
-
-    def _on_global_switch_toggled(self, widget, state: bool) -> bool:
-        try:
-            self.controller.data_manager._daemon.set_suspended(state)
-        except Exception as e:
-            logger.error("Failed to toggle global suspend state: %s", e)
-        self._update_global_switch()
-        return False

--- a/inputremapper/injection/injector.py
+++ b/inputremapper/injection/injector.py
@@ -212,7 +212,12 @@ class Injector(multiprocessing.Process):
         Can be safely called from the main procss.
         """
         logger.info('Stopping injecting keycodes for group "%s"', self.group.key)
-        self._msg_pipe[1].send(InjectorCommand.CLOSE)
+        try:
+            self._msg_pipe[1].send(InjectorCommand.CLOSE)
+        except OSError:
+            logger.debug(
+                "Failed to send CLOSE to injector process, it might already be terminated"
+            )
 
     """Process internal stuff."""
 

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -577,6 +577,68 @@ class TestDaemon(unittest.TestCase):
         self.assertEqual(self.daemon.get_state(group.key), InjectorState.STARTING)
         self.assertIsNotNone(groups.find(key="Foo Device 2"))
 
+    def test_global_suspend_resume(self):
+        preset_name = "test-preset-suspend"
+        group = groups.find(key="Foo Device 2")
+
+        preset = Preset(group.get_preset_path(preset_name))
+        preset.add(
+            Mapping.from_combination(
+                InputCombination([InputConfig(type=1, code=KEY_B)]),
+                "keyboard",
+                "a",
+            )
+        )
+        preset.save()
+
+        self.daemon = Daemon(
+            self.global_config,
+            self.global_uinputs,
+            self.mapping_parser,
+        )
+
+        # Initially, not suspended
+        self.assertFalse(self.daemon.is_suspended())
+
+        # Start injecting
+        self.daemon.start_injecting(group.key, preset_name)
+        self.assertIn(
+            self.daemon.get_state(group.key),
+            (InjectorState.STARTING, InjectorState.RUNNING),
+        )
+        self.assertNotIn(group.key, self.daemon.suspended_presets)
+
+        # Suspend mapping globally
+        self.daemon.set_suspended(True)
+        # Wait up to 2 seconds for state to transition to STOPPED
+        for _ in range(20):
+            if self.daemon.get_state(group.key) == InjectorState.STOPPED:
+                break
+            time.sleep(0.1)
+
+        self.assertTrue(self.daemon.is_suspended())
+        # All injectors should be stopped
+        self.assertEqual(self.daemon.get_state(group.key), InjectorState.STOPPED)
+        # Suspended preset should be recorded in memory
+        self.assertEqual(self.daemon.suspended_presets[group.key], preset_name)
+
+        # Resume mapping globally
+        self.daemon.set_suspended(False)
+        # Wait up to 2 seconds for state to transition to STARTING/RUNNING
+        for _ in range(20):
+            state = self.daemon.get_state(group.key)
+            if state in (InjectorState.STARTING, InjectorState.RUNNING):
+                break
+            time.sleep(0.1)
+
+        self.assertFalse(self.daemon.is_suspended())
+        # Injectors should be restarted
+        self.assertIn(
+            self.daemon.get_state(group.key),
+            (InjectorState.STARTING, InjectorState.RUNNING),
+        )
+        self.assertNotIn(group.key, self.daemon.suspended_presets)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Add a way to globally suspend and resume input remapper without losing its active configuration.