### PR TITLE
fix: set all timeouts 10s to not crash on slow HDD

### DIFF
--- a/inputremapper/bin/input_remapper_control.py
+++ b/inputremapper/bin/input_remapper_control.py
@@ -286,7 +286,7 @@ class InputRemapperControlBin:
                 device,
                 group.key,
             )
-            self.daemon.autoload_single(group.key, timeout=2000)
+            self.daemon.autoload_single(group.key, timeout=10000)
 
     def internals(self, command: str, debug: bool) -> None:
         """Methods that are needed to get the gui to work and that require root.

--- a/inputremapper/daemon.py
+++ b/inputremapper/daemon.py
@@ -268,7 +268,7 @@ class Daemon:
         if UserUtils.user != "root":
             config_path = PathUtils.get_config_path()
             logger.debug('Telling service about "%s"', config_path)
-            proxy.set_config_dir(PathUtils.get_config_path(), timeout=2000)
+            proxy.set_config_dir(PathUtils.get_config_path(), timeout=BUS_TIMEOUT)
 
         return proxy
 


### PR DESCRIPTION
This fixes a rare crash today upon login on a slow SMR HDD. Cold booting, my desktop sometimes takes half a minute to appear, and a previous 2 second timeout was too short. The previous code used 10 second timeouts elsewhere, and this PR uses them everywhere.
# Before

```text
Jul 18 07:47:29 daniel-desktop3 bash[5749]: Traceback (most recent call last):
Jul 18 07:47:29 daniel-desktop3 bash[5749]:   File "/usr/bin/input-remapper-control", line 49, in <module>
Jul 18 07:47:29 daniel-desktop3 bash[5749]:     InputRemapperControlBin.main(InputRemapperControlBin.parse_args())
Jul 18 07:47:29 daniel-desktop3 bash[5749]:     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jul 18 07:47:29 daniel-desktop3 bash[5749]:   File "/usr/lib/python3/dist-packages/inputremapper/bin/input_remapper_control.py", line 116, in main
Jul 18 07:47:29 daniel-desktop3 bash[5749]:     daemon = Daemon.connect(fallback=False)
Jul 18 07:47:29 daniel-desktop3 bash[5749]:   File "/usr/lib/python3/dist-packages/inputremapper/daemon.py", line 277, in connect
Jul 18 07:47:29 daniel-desktop3 bash[5749]:     interface.set_config_dir(PathUtils.get_config_path(), timeout=2)
Jul 18 07:47:29 daniel-desktop3 bash[5749]:     ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jul 18 07:47:29 daniel-desktop3 bash[5749]:   File "/usr/lib/python3/dist-packages/pydbus/proxy_method.py", line 72, in __call__
Jul 18 07:47:29 daniel-desktop3 bash[5749]:     ret = instance._bus.con.call_sync(
Jul 18 07:47:29 daniel-desktop3 bash[5749]:           ~~~~~~~~~~~~~~~~~~~~~~~~~~~^
Jul 18 07:47:29 daniel-desktop3 bash[5749]:             instance._bus_name, instance._path,
Jul 18 07:47:29 daniel-desktop3 bash[5749]:      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jul 18 07:47:29 daniel-desktop3 bash[5749]:             self._iface_name, self.__name__, GLib.Variant(self._sinargs, args), GLib.VariantType.new(self._soutargs),
Jul 18 07:47:29 daniel-desktop3 bash[5749]:      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jul 18 07:47:29 daniel-desktop3 bash[5749]:             0, timeout_to_glib(timeout), None).unpack()
Jul 18 07:47:29 daniel-desktop3 bash[5749]:      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Jul 18 07:47:29 daniel-desktop3 bash[5749]: gi.repository.GLib.GError: g-io-error-quark: Timeout was reached (24)
Jul 18 07:47:29 daniel-desktop3 systemd[4619]: app-input\x2dremapper\x2dautoload@autostart.service: Main process exited, code=exited, status=1/FAILURE
Jul 18 07:47:29 daniel-desktop3 systemd[4619]: app-input\x2dremapper\x2dautoload@autostart.service: Failed with result 'exit-code'.
Jul 18 07:47:29 daniel-desktop3 systemd[4619]: app-input\x2dremapper\x2dautoload@autostart.service: Consumed 2.180s CPU time over 1min 40.715s wall clock time, 168.4M memory peak.
```

# After

This crash should be less likely.