### PR TITLE
add ExecStop to service

### DIFF
--- a/data/input-remapper.service
+++ b/data/input-remapper.service
@@ -8,6 +8,7 @@ After=dbus.service
 Type=dbus
 BusName=inputremapper.Control
 ExecStart=/usr/bin/input-remapper-service
+ExecStop=/usr/bin/input-remapper-control --command quit
 
 [Install]
 WantedBy=default.target

--- a/inputremapper/bin/input_remapper_control.py
+++ b/inputremapper/bin/input_remapper_control.py
@@ -26,10 +26,7 @@ import subprocess
 import sys
 from enum import Enum
 
-import gi
-
-gi.require_version("GLib", "2.0")
-from gi.repository import GLib
+from dasbus.error import DBusError
 
 from inputremapper.configs.global_config import GlobalConfig
 from inputremapper.configs.migrations import Migrations
@@ -232,8 +229,8 @@ class InputRemapperControlBin:
     def _quit(self) -> None:
         try:
             self.daemon.quit()
-        except GLib.GError as error:
-            if "NoReply" in str(error):
+        except DBusError as error:
+            if error.dbus_name == "org.freedesktop.DBus.Error.NoReply":
                 # The daemon is expected to terminate, so there won't be a reply.
                 return
 


### PR DESCRIPTION
Package upgrades can cause a race condition when restarting `input-remapper` before the previous daemon releases its D-Bus name. This adds `ExecStop` using the daemon’s `quit` command to ensure it is released and treats the expected `NoReply` as success.

This issue would cause `arch-update` to report a failure restarting the `input-remapper` service every time I update.