### PR TITLE
Fix hold_keys dropping duplicate keys in + syntax (#1347)

### DIFF
--- a/inputremapper/injection/macros/tasks/hold_keys.py
+++ b/inputremapper/injection/macros/tasks/hold_keys.py
@@ -44,12 +44,26 @@ class HoldKeysTask(Task):
 
         codes = [keyboard_layout.get(symbol) for symbol in symbols]
 
+        held_codes = set()
         for code in codes:
+            if code in held_codes:
+                # Release and re-press to support duplicate keys in a sequence
+                callback(EV_KEY, code, 0)
+                await self.keycode_pause()
             callback(EV_KEY, code, 1)
+            held_codes.add(code)
             await self.keycode_pause()
 
         await self._trigger_release_event.wait()
 
-        for code in codes[::-1]:
+        # Release each unique code once, in reverse order of first appearance
+        seen = set()
+        unique_codes_reversed = []
+        for code in reversed(codes):
+            if code not in seen:
+                seen.add(code)
+                unique_codes_reversed.append(code)
+
+        for code in unique_codes_reversed:
             callback(EV_KEY, code, 0)
             await self.keycode_pause()

--- a/tests/unit/test_macros/test_hold_keys.py
+++ b/tests/unit/test_macros/test_hold_keys.py
@@ -120,6 +120,78 @@ class TestHoldKeys(MacroTestBase):
         self.assertEqual(self.result[6], (EV_KEY, keyboard_layout.get("b"), 0))
         self.assertEqual(self.result[7], (EV_KEY, keyboard_layout.get("a"), 0))
 
+    async def test_hold_keys_with_duplicates(self):
+        macro = Parser.parse(
+            "hold_keys(KEY_4, KEY_3, KEY_5, KEY_5, KEY_9)", self.context, DummyMapping
+        )
+
+        code_4 = keyboard_layout.get("KEY_4")
+        code_3 = keyboard_layout.get("KEY_3")
+        code_5 = keyboard_layout.get("KEY_5")
+        code_9 = keyboard_layout.get("KEY_9")
+
+        macro.press_trigger()
+        asyncio.ensure_future(macro.run(self.handler))
+        await asyncio.sleep(0.2)
+
+        # Duplicate KEY_5 should be released and re-pressed
+        self.assertListEqual(
+            self.result,
+            [
+                (EV_KEY, code_4, 1),
+                (EV_KEY, code_3, 1),
+                (EV_KEY, code_5, 1),
+                (EV_KEY, code_5, 0),
+                (EV_KEY, code_5, 1),
+                (EV_KEY, code_9, 1),
+            ],
+        )
+
+        macro.release_trigger()
+        await asyncio.sleep(0.2)
+
+        # Each unique code released once, in reverse order of first appearance
+        self.assertListEqual(
+            self.result[6:],
+            [
+                (EV_KEY, code_9, 0),
+                (EV_KEY, code_5, 0),
+                (EV_KEY, code_3, 0),
+                (EV_KEY, code_4, 0),
+            ],
+        )
+
+    async def test_plus_syntax_with_duplicates(self):
+        macro = Parser.parse("KEY_5 + KEY_5 + KEY_3", self.context, DummyMapping)
+
+        code_5 = keyboard_layout.get("KEY_5")
+        code_3 = keyboard_layout.get("KEY_3")
+
+        macro.press_trigger()
+        asyncio.ensure_future(macro.run(self.handler))
+        await asyncio.sleep(0.2)
+
+        self.assertListEqual(
+            self.result,
+            [
+                (EV_KEY, code_5, 1),
+                (EV_KEY, code_5, 0),
+                (EV_KEY, code_5, 1),
+                (EV_KEY, code_3, 1),
+            ],
+        )
+
+        macro.release_trigger()
+        await asyncio.sleep(0.2)
+
+        self.assertListEqual(
+            self.result[4:],
+            [
+                (EV_KEY, code_3, 0),
+                (EV_KEY, code_5, 0),
+            ],
+        )
+
     async def test_raises_error(self):
         self.assertRaises(
             MacroError, Parser.parse, "hold_keys(a, broken, b)", self.context


### PR DESCRIPTION
Fixes #1347 

**Problem**
When using the + syntax with repeated keys (e.g., KEY_4+KEY_3+KEY_5+KEY_5+KEY_9), duplicate keys were silently dropped because pressing an already-held key is a no-op at the kernel level.

**Solution**
The fix releases a key before re-pressing it when a duplicate is encountered in hold_keys, so that sequences like KEY_5+KEY_5 properly output both keystrokes.

**What was changed**
- inputremapper/injection/macros/tasks/hold_keys.py — track held codes and release before re-pressing duplicates; release each unique code once on trigger release
- tests/unit/test_macros/test_hold_keys.py — added tests for duplicate keys in both hold_keys() and + syntax

Before: KEY_4+KEY_3+KEY_5+KEY_5+KEY_9+KEY_4+KEY_1+KEY_2+KEY_8+KEY_5 = 4359128
After: KEY_4+KEY_3+KEY_5+KEY_5+KEY_9+KEY_4+KEY_1+KEY_2+KEY_8+KEY_5 = 4355941285
