### PR TITLE
Add while_eq macro: variable-driven loop stoppable from another mapping

### DIFF
--- a/inputremapper/injection/macros/parse.py
+++ b/inputremapper/injection/macros/parse.py
@@ -49,6 +49,7 @@ from inputremapper.injection.macros.tasks.mouse_xy import MouseXYTask
 from inputremapper.injection.macros.tasks.repeat import RepeatTask
 from inputremapper.injection.macros.tasks.set import SetTask
 from inputremapper.injection.macros.tasks.toggle import ToggleTask
+from inputremapper.injection.macros.tasks.while_eq import WhileEqTask
 from inputremapper.injection.macros.tasks.wait import WaitTask
 from inputremapper.injection.macros.tasks.wheel import WheelTask
 from inputremapper.logging.logger import logger
@@ -63,6 +64,7 @@ class Parser:
         "modify": ModifyTask,
         "repeat": RepeatTask,
         "toggle": ToggleTask,
+        "while_eq": WhileEqTask,
         "key": KeyTask,
         "key_down": KeyDownTask,
         "key_up": KeyUpTask,

--- a/inputremapper/injection/macros/tasks/while_eq.py
+++ b/inputremapper/injection/macros/tasks/while_eq.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# input-remapper - GUI for device specific keyboard mappings
+# Copyright (C) 2025 sezanzeb <b8x45ygc9@mozmail.com>
+#
+# This file is part of input-remapper.
+#
+# input-remapper is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# input-remapper is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with input-remapper.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+import asyncio
+
+from inputremapper.injection.macros.argument import ArgumentConfig
+from inputremapper.injection.macros.macro import Macro
+from inputremapper.injection.macros.task import Task
+
+
+class WhileEqTask(Task):
+    """Repeat a macro while a shared variable equals a value.
+
+    Named to mirror `if_eq(value_1, value_2, then, else)`. Unlike `toggle`,
+    which starts/stops on repeated presses of the same trigger, `while_eq`
+    is driven by a `set()`/`add()` variable that any other mapping can
+    write to, so a *different* key can stop the loop. Unlike `repeat`, the
+    variable is re-read every iteration instead of a fixed count being
+    decided once at the start, so the loop actually returns (freeing the
+    macro to be re-triggered) as soon as the condition flips, rather than
+    idling through a fixed budget.
+    """
+
+    argument_configs = [
+        ArgumentConfig(
+            name="variable",
+            position=0,
+            types=[str, float, int, None],
+            is_variable_name=True,
+        ),
+        ArgumentConfig(
+            name="value",
+            position=1,
+            types=[str, float, int, None],
+        ),
+        ArgumentConfig(
+            name="macro",
+            position=2,
+            types=[Macro],
+        ),
+    ]
+
+    async def run(self, callback) -> None:
+        variable = self.get_argument("variable")
+        value = self.get_argument("value").get_value()
+        macro = self.get_argument("macro").get_value()
+
+        while variable.get_value() == value:
+            await macro.run(callback)
+            await asyncio.sleep(1 / 1000)

--- a/readme/macros.md
+++ b/readme/macros.md
@@ -89,6 +89,29 @@ Bear in mind that anti-cheat software might detect macros in games.
 > toggle(key(KEY_A))
 > ```
 
+### while_eq
+
+> Repeats the execution of the third parameter while a variable equals a
+> value. Unlike `toggle`, which starts/stops by pressing the same input
+> again, `while_eq` is controlled by a `set()`/`add()` variable that a
+> *different* mapping can change, so one key can stop a loop that another
+> key started. Unlike `repeat`, the variable is re-checked every iteration
+> instead of a fixed number of repeats being decided up front, so the
+> macro actually finishes as soon as the condition no longer holds, rather
+> than running out a fixed budget before it can be triggered again.
+>
+> ```ts
+> while_eq(variable: str, value: str | int, macro: Macro)
+> ```
+>
+> Examples:
+>
+> ```ts
+> # left mouse button autoclicker, toggled by one key and stopped by another
+> set(clicking, 1).while_eq(clicking, 1, key(BTN_LEFT).wait(50))
+> # elsewhere: set(clicking, 0) stops it
+> ```
+
 ### modify
 
 > Holds a modifier while executing the second parameter

--- a/tests/unit/test_macros/test_while_eq.py
+++ b/tests/unit/test_macros/test_while_eq.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# input-remapper - GUI for device specific keyboard mappings
+# Copyright (C) 2025 sezanzeb <b8x45ygc9@mozmail.com>
+#
+# This file is part of input-remapper.
+#
+# input-remapper is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# input-remapper is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with input-remapper.  If not, see <https://www.gnu.org/licenses/>.
+
+import asyncio
+import unittest
+
+from inputremapper.configs.validation_errors import MacroError
+from inputremapper.injection.macros.macro import macro_variables
+from inputremapper.injection.macros.parse import Parser
+from tests.lib.test_setup import test_setup
+from tests.unit.test_macros.macro_test_base import MacroTestBase, DummyMapping
+
+
+@test_setup
+class TestWhileEq(MacroTestBase):
+    async def test_does_not_run_when_condition_is_already_false(self):
+        macro_variables.set("while_eq_a", 0)
+        macro = Parser.parse(
+            "while_eq(while_eq_a, 1, key(a))", self.context, DummyMapping
+        )
+        await macro.run(self.handler)
+        self.assertListEqual(self.result, [])
+        self.assertFalse(macro.running)
+
+    async def test_stops_when_variable_changes(self):
+        macro_variables.set("while_eq_b", 1)
+        macro = Parser.parse(
+            "while_eq(while_eq_b, 1, key(a).wait(10))", self.context, DummyMapping
+        )
+
+        async def stop_soon():
+            await asyncio.sleep(0.05)
+            # simulating a *different* mapping's `set()` stopping this loop
+            macro_variables.set("while_eq_b", 0)
+
+        asyncio.ensure_future(stop_soon())
+        await asyncio.wait_for(macro.run(self.handler), timeout=1)
+
+        # it actually ran the child macro at least once while the
+        # condition was true
+        self.assertGreater(len(self.result), 0)
+
+        # and it returned (not just idling) once the condition became false,
+        # unlike `repeat`, which keeps a fixed count running regardless
+        self.assertFalse(macro.running)
+
+    async def test_can_be_retriggered_immediately_after_stopping(self):
+        # this is the whole point of `while_eq` over `repeat`+`if_eq`: since
+        # the loop actually returns instead of running out a fixed budget,
+        # the macro can be started again right away
+        macro_variables.set("while_eq_c", 1)
+        macro = Parser.parse(
+            "while_eq(while_eq_c, 1, key(a).wait(10))", self.context, DummyMapping
+        )
+
+        async def stop_soon():
+            await asyncio.sleep(0.05)
+            macro_variables.set("while_eq_c", 0)
+
+        asyncio.ensure_future(stop_soon())
+        await asyncio.wait_for(macro.run(self.handler), timeout=1)
+        self.assertFalse(macro.running)
+
+        macro_variables.set("while_eq_c", 1)
+
+        async def stop_again_soon():
+            await asyncio.sleep(0.05)
+            macro_variables.set("while_eq_c", 0)
+
+        asyncio.ensure_future(stop_again_soon())
+        # if the first run left the macro "running", this would silently
+        # do nothing and the timeout would never be hit
+        await asyncio.wait_for(macro.run(self.handler), timeout=1)
+        self.assertFalse(macro.running)
+
+    async def test_raises_error(self):
+        # missing the macro argument
+        self.assertRaises(
+            MacroError, Parser.parse, "while_eq(a, 1)", self.context
+        )
+        Parser.parse("while_eq(a, 1, key(a))", self.context)  # no error
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

I wanted an autoclicker toggled on by one key and stopped by a *different*
key (e.g. Shift+F4 starts clicking, F4 stops it and also releases a
held button from a third mapping). `toggle()` doesn't fit: it only
starts/stops on a second press of the *same* trigger, so an unrelated
key has no way to reach it.

The natural workaround is `repeat(N, if_eq($var, 1, click, wait))` driven
by a shared `set()`/`if_eq()` variable — but this runs into a sharper
problem than just "clicking never stops immediately". `RepeatTask.run()`
reads its count once and loops a plain `for _ in range(repeats)`, with no
way to exit early:

https://github.com/sezanzeb/input-remapper/blob/2.2.1/inputremapper/injection/macros/tasks/repeat.py#L44-L49

Meanwhile `Macro.run()` refuses to start a second execution while the
first is still "running":

https://github.com/sezanzeb/input-remapper/blob/2.2.1/inputremapper/injection/macros/macro.py#L83-L87

So even after the shared variable flips to stop the clicking, the macro
instance keeps occupying that mapping's "running" slot until the fixed
repeat count exhausts — which can be minutes depending on how the count
was sized — silently swallowing every re-press of the trigger key in the
meantime. From the user's perspective: works once, then appears to just
stop responding.

## Fix

`while_eq(variable, value, macro)` re-reads the variable every iteration
(like `if_eq` does) instead of deciding a count up front (like `repeat`
does), so `run()` actually *returns* as soon as the condition no longer
holds:

```ts
set(clicking, 1).while_eq(clicking, 1, key(BTN_LEFT).wait(50))
# a different mapping: set(clicking, 0) stops it, and the macro is
# immediately retriggerable — it isn't still "running" a leftover budget
```

This required a genuinely new task rather than composing existing ones —
none of `repeat`/`hold`/`toggle`/`if_tap`/`if_single` support an
externally-driven, unbounded, promptly-exiting loop; `hold`/`toggle`'s
early-exit mechanism (`press_trigger()`/`release_trigger()`) is scoped to
the *same* trigger that started them, and `repeat`'s bound is fixed at
start with no way to shorten it once running.

## Changes

- `inputremapper/injection/macros/tasks/while_eq.py` — new task
- `inputremapper/injection/macros/parse.py` — registers `while_eq` in `TASK_CLASSES`
- `readme/macros.md` — docs entry alongside `toggle`
- `tests/unit/test_macros/test_while_eq.py` — covers: no-op when the
  condition starts false, stopping promptly when the variable is changed
  by other code mid-loop, and immediate re-triggerability after stopping

Ran the full `tests/unit/test_macros` suite locally (134 tests, all
passing) plus the new file on its own.

Happy to adjust naming/placement/docs wording if you'd prefer something
different — `while_eq` was chosen to mirror `if_eq`'s naming rather than
introduce an unrelated verb (I'd originally called it `until`, which is
backwards — `until` conventionally means "loop while false", and this
loops while *true*).