### PR TITLE
fix: reader-service pipe paths built from home directory instead of username

### DIFF
--- a/inputremapper/gui/reader_service.py
+++ b/inputremapper/gui/reader_service.py
@@ -127,8 +127,8 @@ class ReaderService:
     def get_pipe_paths() -> Tuple[str, str]:
         """Get the path where the pipe can be found."""
         return (
-            f"/tmp/input-remapper-{UserUtils.home}/reader-results",
-            f"/tmp/input-remapper-{UserUtils.home}/reader-commands",
+            f"/tmp/input-remapper-{UserUtils.user}/reader-results",
+            f"/tmp/input-remapper-{UserUtils.user}/reader-commands",
         )
 
     @staticmethod


### PR DESCRIPTION
## Problem

Opening the GUI (`input-remapper-gtk`) fails while connecting to the
reader-service, with:

    OSError: [Errno 6] No such device or address:
    '/tmp/input-remapper-/home/<user>/reader-resultsr'

The pipe path itself is malformed — `/home/<user>` is embedded where
a bare username belongs, producing a nested path nothing ever
actually creates.

## Root cause

`ReaderService.get_pipe_paths()` in `inputremapper/gui/reader_service.py`
builds its pipe paths like this:

```python
return (
    f"/tmp/input-remapper-{UserUtils.home}/reader-results",
    f"/tmp/input-remapper-{UserUtils.home}/reader-commands",
)
```

`UserUtils.home` is a full filesystem path (`pwd.getpwnam(user).pw_dir`),
not a username. Since every home directory is an absolute path, this
always contains at least one `/`, and interpolating it here produces
a broken multi-level path every time — not just for unusual usernames,
for every user, unconditionally.

Comparing against `2.0.1`, the last version before this broke, the
same method used `UserUtils.user` (a bare username) instead:

```python
return (
    f"/tmp/input-remapper-{USER}/reader-results",
    f"/tmp/input-remapper-{USER}/reader-commands",
)
```

That's a well-formed path (`/tmp/input-remapper-someuser/...`), which is
also what every working setup in this repo's own issue history actually
shows (`/tmp/input-remapper-christian/...`, `/tmp/input-remapper-
exspiravit/...`, `/tmp/input-remapper-jvadair/...` — usernames, not paths).

I checked every other place `UserUtils.home` is used in the codebase
before touching anything, to make sure this fix doesn't overreach:
`configs/paths.py` and `configs/migrations.py` both correctly pass it
through `os.path.join()`, since those genuinely need a real filesystem
path to locate config files. This PR only touches the one place a path
was being hand-built with an f-string instead.

## Fix

```diff
     def get_pipe_paths() -> Tuple[str, str]:
         """Get the path where the pipe can be found."""
         return (
-            f"/tmp/input-remapper-{UserUtils.home}/reader-results",
-            f"/tmp/input-remapper-{UserUtils.home}/reader-commands",
+            f"/tmp/input-remapper-{UserUtils.user}/reader-results",
+            f"/tmp/input-remapper-{UserUtils.user}/reader-commands",
         )
```

`pipes_exist()` a few lines below calls `get_pipe_paths()[0]` internally,
so it inherits the fix automatically — no separate change needed there.

## Related issues

- #1282 shows the identical broken path shape
  (`/tmp/input-remapper-/home/untitled1/reader-resultsr`) on 2.2.0 —
  same root cause, same regression window.

Fixes #1282